### PR TITLE
UI to manage Service scores

### DIFF
--- a/src/views/services/Create.vue
+++ b/src/views/services/Create.vue
@@ -79,6 +79,7 @@
                 :url.sync="form.url"
                 @update:logo_file_id="form.logo_file_id = $event"
                 :status.sync="form.status"
+                :score.sync="form.score"
                 :ends_at.sync="form.ends_at"
                 :gallery_items.sync="form.gallery_items"
               >
@@ -223,6 +224,7 @@ export default {
         slug: "",
         type: "service",
         status: "inactive",
+        score: "",
         intro: "",
         description: "",
         wait_time: null,

--- a/src/views/services/Edit.vue
+++ b/src/views/services/Edit.vue
@@ -50,6 +50,7 @@
                   @update:logo_file_id="form.logo_file_id = $event"
                   @update:logo="form.logo = $event"
                   :status.sync="form.status"
+                  :score.sync="form.score"
                   :ends_at.sync="form.ends_at"
                   :gallery_items.sync="form.gallery_items"
                   :id="service.id"
@@ -292,6 +293,7 @@ export default {
         slug: this.service.slug,
         type: this.service.type,
         status: this.service.status,
+        score: this.service.score || "",
         intro: this.service.intro,
         description: this.service.description,
         wait_time: this.service.wait_time,
@@ -355,6 +357,9 @@ export default {
           }
           if (data.status === this.service.status) {
             delete data.status;
+          }
+          if (data.score === this.service.score) {
+            delete data.score;
           }
           if (data.intro === this.service.intro) {
             delete data.intro;

--- a/src/views/services/forms/DetailsTab.vue
+++ b/src/views/services/forms/DetailsTab.vue
@@ -82,6 +82,22 @@
           :error="errors.get('url')"
         />
 
+        <ck-select-input
+          :value="score"
+          @input="
+            $emit('update:score', $event);
+            $emit('clear', 'score');
+          "
+          id="score"
+          label="Quality Score"
+          :hint="
+            `Rate the overall effectiveness and quality of the ${type} between 1 (poor) and 5 (excellent). This is not displayed but affects positioning within search results.`
+          "
+          :options="scoreOptions"
+          :error="errors.get('score')"
+          v-if="auth.isSuperAdmin"
+        />
+
         <ck-image-input
           @input="
             $emit('update:logo_file_id', $event.file_id);
@@ -192,6 +208,9 @@ export default {
     status: {
       required: true
     },
+    score: {
+      required: true
+    },
     ends_at: {
       required: true
     },
@@ -216,6 +235,14 @@ export default {
       statusOptions: [
         { label: "Enabled", value: "active" },
         { label: "Disabled", value: "inactive" }
+      ],
+      scoreOptions: [
+        { text: "Unrated", value: "" },
+        { text: "Poor", value: 1 },
+        { text: "Below Average", value: 2 },
+        { text: "Average", value: 3 },
+        { text: "Above Average", value: 4 },
+        { text: "Excellent", value: 5 }
       ]
     };
   },

--- a/src/views/services/show/DetailsTab.vue
+++ b/src/views/services/show/DetailsTab.vue
@@ -69,6 +69,10 @@
             v-html="service.status === 'active' ? 'Enabled' : 'Disabled'"
           />
         </gov-table-row>
+        <gov-table-row v-if="auth.isSuperAdmin">
+          <gov-table-header top scope="row">Quality Score</gov-table-header>
+          <gov-table-cell v-html="qualityScores[service.score]" />
+        </gov-table-row>
         <gov-table-row>
           <gov-table-header top scope="row">End date</gov-table-header>
           <gov-table-cell>{{ service.ends_at | endsAt }}</gov-table-cell>
@@ -120,7 +124,15 @@ export default {
 
   data() {
     return {
-      refreshForm: new Form({})
+      refreshForm: new Form({}),
+      qualityScores: {
+        0: "Unrated",
+        1: "Poor",
+        2: "Below Average",
+        3: "Average",
+        4: "Above Average",
+        5: "Excellent"
+      }
     };
   },
 

--- a/src/views/update-requests/show/ServiceDetails.vue
+++ b/src/views/update-requests/show/ServiceDetails.vue
@@ -97,6 +97,14 @@
           <gov-table-cell>{{ service.status | status }}</gov-table-cell>
         </gov-table-row>
 
+        <gov-table-row v-if="service.hasOwnProperty('score')">
+          <gov-table-header top scope="row">Quality Score</gov-table-header>
+          <gov-table-cell v-if="original">{{
+            original.score | score
+          }}</gov-table-cell>
+          <gov-table-cell>{{ service.score | score }}</gov-table-cell>
+        </gov-table-row>
+
         <gov-table-row v-if="service.hasOwnProperty('ends_at')">
           <gov-table-header top scope="row">End date</gov-table-header>
           <gov-table-cell>{{ original.ends_at | endsAt }}</gov-table-cell>
@@ -712,6 +720,18 @@ export default {
   filters: {
     status(status) {
       return status === "active" ? "Enabled" : "Disabled";
+    },
+
+    score(score) {
+      const qualityScores = {
+        0: "Unrated",
+        1: "Poor",
+        2: "Below Average",
+        3: "Average",
+        4: "Above Average",
+        5: "Excellent"
+      };
+      return qualityScores[score];
     },
 
     isFree(isFree) {


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/2418/boost-services-in-search-results

- Added UI to manage service scores
- Imported code from https://github.com/Healthy-London-Partnership/admin/pull/22
- Imported code from https://github.com/Healthy-London-Partnership/admin/pull/51/commits

### Development checklist
- [ ] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
