### PR TITLE
Derive admin url in staging warning from environment

### DIFF
--- a/src/components/CkEnvironmentWarning.vue
+++ b/src/components/CkEnvironmentWarning.vue
@@ -5,9 +5,7 @@
         Please DO NOT make any changes to this site. This is a TEST environment
         used for demo purposes only. Any changes made here will not be reflected
         on the LIVE site viewed by the public.
-        <gov-link href="https://admin.suttoninformationhub.org.uk/"
-          >Click HERE
-        </gov-link>
+        <gov-link :href="adminUrl">Click HERE </gov-link>
         to access the LIVE environment.
       </gov-warning-text>
     </gov-width-container>
@@ -21,6 +19,9 @@ export default {
   computed: {
     environment() {
       return process.env.VUE_APP_ENV;
+    },
+    adminUrl() {
+      return String(process.env.VUE_APP_URI).replace("staging.", "");
     }
   }
 };


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/2459/update-hyerplink-in-staging-warning-banner

- Removed hardcoded admin url in staging warning banner and replaced with url generated form the environment

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
