### PR TITLE
removed ref to aunt bertha standards from category taxonomies

### DIFF
--- a/src/views/admin/index/taxonomies/Categories.vue
+++ b/src/views/admin/index/taxonomies/Categories.vue
@@ -6,11 +6,7 @@
 
         <gov-body>
           Taxonomies are the 'tags' that we assign to services, in order for
-          them to appear within search results and categories. They are pulled
-          from the
-          <gov-link href="https://about.auntbertha.com/openeligibility"
-            >Aunt Bertha Open Eligibility Standard</gov-link
-          >.
+          them to appear within search results and categories.
         </gov-body>
 
         <gov-body>
@@ -32,7 +28,7 @@
     <gov-section-break size="l" />
 
     <!-- Loop through each taxonomy -->
-    <ck-loader v-if="loading" />
+    <ck-loader v-if="loading"></ck-loader>
     <div v-else v-for="(taxonomy, index) in taxonomies" :key="index">
       <gov-grid-row>
         <gov-grid-column width="two-thirds">


### PR DESCRIPTION
### Summary
https://paste-trello-link-here

-Removed text "They are pulled from the Aunt Bertha Open Eligibility Standard" from the Admin Taxonomies Categories tab

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
