### PR TITLE
Converted wysiwyg character count to a bar

### DIFF
--- a/src/components/Ck/CkCharacterCountBar.vue
+++ b/src/components/Ck/CkCharacterCountBar.vue
@@ -1,0 +1,62 @@
+<template>
+  <div class="ck-character-bar-container">
+    <div
+      class="ck-character-bar"
+      :style="{ backgroundColor: barColour, width: barWidthStyle }"
+    ></div>
+    <gov-error-message
+      v-if="barWidth >= 100"
+      v-text="'Character count exceeded'"
+      for="chracter-count"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  name: "CkCharacterCountBar",
+
+  props: {
+    count: {
+      type: Number,
+      required: true,
+    },
+
+    maxLength: {
+      type: Number,
+      required: true,
+    },
+  },
+
+  computed: {
+    barColour() {
+      return this.barWidth < 90
+        ? "green"
+        : this.barWidth < 100
+        ? "orange"
+        : "red";
+    },
+    barWidth() {
+      const width = Math.floor((this.count / this.maxLength) * 100);
+      return width < 100 ? width : 100;
+    },
+    barWidthStyle() {
+      return `${this.barWidth}%`;
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+@import "../../scss/app.scss";
+
+.ck-character-bar-container {
+  @extend .govuk-body;
+
+  margin: 0;
+  color: $govuk-secondary-text-colour;
+}
+.ck-character-bar {
+  padding-top: 0.5rem;
+}
+</style>

--- a/src/components/Ck/CkWysiwygInput.vue
+++ b/src/components/Ck/CkWysiwygInput.vue
@@ -17,7 +17,7 @@
         :large="large"
         :extensions="extensions"
       />
-      <ck-character-count
+      <ck-character-count-bar
         v-if="maxlength"
         :count="count"
         :max-length="maxlength"
@@ -31,7 +31,7 @@
 </template>
 
 <script>
-import CkCharacterCount from "@/components/Ck/CkCharacterCount.vue";
+import CkCharacterCountBar from "@/components/Ck/CkCharacterCountBar.vue";
 import CkCharacterCountGroup from "@/components/Ck/CkCharacterCountGroup.vue";
 import {
   Blockquote,
@@ -46,7 +46,7 @@ import {
 
 export default {
   name: "CkWysiwygInput",
-  components: { CkCharacterCount, CkCharacterCountGroup },
+  components: { CkCharacterCountBar, CkCharacterCountGroup },
   props: {
     value: {
       required: true,

--- a/src/components/CkWysiwyg.vue
+++ b/src/components/CkWysiwyg.vue
@@ -160,11 +160,9 @@ export default {
 
   methods: {
     onEdit(html) {
-      const div = document.createElement("div");
-      div.innerHTML = html;
-      this.$emit("count", div.textContent.length);
-
       const markdown = this.toMarkdown(html);
+      this.$emit("count", markdown.length);
+
       this.$emit("input", markdown);
     },
 
@@ -176,7 +174,8 @@ export default {
   mounted() {
     const element = document.createElement("div");
     element.innerHTML = this.editor.getHTML();
-    this.$emit("count", element.textContent.length);
+    const markdown = this.toMarkdown(this.editor.getHTML());
+    this.$emit("count", markdown.length);
   },
 
   beforeDestroy() {


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/2628/character-count-validation-logic-on-service-description

- Converted character count to display a bar showing how much of the character limit has been used.
- Character count is now based on markdown length so will align with the way the string is counted in the API request valiadtion

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
