### PR TITLE
Sutton sc 2755 create a new content admin user role

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -58,19 +58,40 @@ export default {
     },
     loggedInItems() {
       return [
-        { text: "Services", to: { name: "services-index" } },
-        { text: "Locations", to: { name: "locations-index" } },
-        { text: "Referrals", to: { name: "referrals-index" } },
+        {
+          text: "Services",
+          to: { name: "services-index" },
+          hide: Auth.isOnlyContentAdmin,
+        },
+        {
+          text: "Locations",
+          to: { name: "locations-index" },
+          hide: Auth.isOnlyContentAdmin,
+        },
+        {
+          text: "Referrals",
+          to: { name: "referrals-index" },
+          hide: Auth.isOnlyContentAdmin,
+        },
         {
           text: "Organisations",
           to: { name: "organisations-index" },
           hide: !Auth.isOrganisationAdmin(),
         },
-        { text: "Events", to: { name: "events-index" } },
-        { text: "Pages", to: { name: "pages-index" } },
+        {
+          text: "Events",
+          to: { name: "events-index" },
+          hide: Auth.isOnlyContentAdmin,
+        },
+        {
+          text: "Pages",
+          to: { name: "pages-index" },
+          hide: !Auth.isContentAdmin,
+        },
         {
           text: "Users",
           to: { name: "users-index" },
+          hide: Auth.isOnlyContentAdmin,
         },
         {
           text: "Reports",

--- a/src/classes/Auth.js
+++ b/src/classes/Auth.js
@@ -184,6 +184,20 @@ class Auth {
   }
 
   /**
+   * @returns {array}
+   */
+  get roles() {
+    return [
+      { text: "Super admin", value: "Super Admin" },
+      { text: "Global admin", value: "Global Admin" },
+      { text: "Content admin", value: "Content Admin" },
+      { text: "Organisation admin", value: "Organisation Admin" },
+      { text: "Service admin", value: "Service Admin" },
+      { text: "Service worker", value: "Service Worker" },
+    ];
+  }
+
+  /**
    * @param {string} roleName
    * @param {object} service
    * @param {object} organisation
@@ -230,6 +244,20 @@ class Auth {
   /**
    * @returns {boolean}
    */
+  get isContentAdmin() {
+    return this.hasRole("Content Admin") || this.isSuperAdmin;
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  get isOnlyContentAdmin() {
+    return this.hasRole("Content Admin") && this.user.roles.length === 1;
+  }
+
+  /**
+   * @returns {boolean}
+   */
   isOrganisationAdmin(organisation = null) {
     return (
       this.hasRole("Organisation Admin", null, organisation) ||
@@ -254,6 +282,22 @@ class Auth {
     return (
       this.hasRole("Service Worker", service) || this.isServiceAdmin(service)
     );
+  }
+
+  /**
+   *
+   * @param {array} roles
+   * @returns {string}
+   */
+  displayHighestRole(userRoles) {
+    const roleNames = this.roles.map((role) => role.value);
+
+    const highestRole = roleNames.find(
+      (roleName) =>
+        userRoles.find((role) => role.role === roleName) !== undefined
+    );
+
+    return highestRole || "None";
   }
 }
 

--- a/src/components/Ck/CkTreeList.vue
+++ b/src/components/Ck/CkTreeList.vue
@@ -3,9 +3,10 @@
     <li v-for="node in nodes" :key="node.id">
       <slot name="label" :node="node">{{ node.label }}</slot
       >&nbsp;
-      <span v-if="canEdit">
+      <span>
         <slot name="edit" :node="node">
           <gov-link
+            v-if="canEdit"
             :to="{
               name: edit,
               params: { [nodeType]: node.id },
@@ -76,11 +77,7 @@ export default {
   },
   computed: {
     canEdit() {
-      return (
-        this.edit.length > 0 &&
-        this.nodeType.length > 0 &&
-        this.auth.isGlobalAdmin
-      );
+      return this.edit.length > 0 && this.nodeType.length > 0;
     },
   },
 };

--- a/src/components/CkUserDetails.vue
+++ b/src/components/CkUserDetails.vue
@@ -23,6 +23,7 @@
           <gov-list>
             <li>Super admin: {{ superAdmin ? "Yes" : "No" }}</li>
             <li>Global admin: {{ globalAdmin ? "Yes" : "No" }}</li>
+            <li>Content admin: {{ contentAdmin ? "Yes" : "No" }}</li>
             <li>
               <template v-if="organisationAdmin.length === 0"
                 >Organisation admin: No</template
@@ -103,6 +104,7 @@ export default {
     return {
       superAdmin: false,
       globalAdmin: false,
+      contentAdmin: false,
       organisationAdmin: [],
       serviceAdmin: [],
       serviceWorker: [],
@@ -121,6 +123,8 @@ export default {
           this.superAdmin = true;
         } else if (role.role === "Global Admin") {
           this.globalAdmin = true;
+        } else if (role.role === "Content Admin") {
+          this.contentAdmin = true;
         } else if (role.hasOwnProperty("organisation_id")) {
           this.organisationAdmin.push(role);
         } else if (

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -24,7 +24,7 @@
       <gov-section-break size="l" />
 
       <gov-grid-row>
-        <gov-grid-column width="one-half">
+        <gov-grid-column width="one-half" v-if="!auth.isOnlyContentAdmin">
           <gov-heading size="l">Services</gov-heading>
           <gov-body>Add or edit your pages on {{ appName }}.</gov-body>
           <gov-button start :to="{ name: 'services-index' }">
@@ -33,7 +33,7 @@
           <gov-section-break size="m" />
         </gov-grid-column>
 
-        <gov-grid-column width="one-half">
+        <gov-grid-column width="one-half" v-if="!auth.isOnlyContentAdmin">
           <gov-heading size="l">Locations</gov-heading>
           <gov-body>View and edit service locations in the Borough.</gov-body>
           <gov-button start :to="{ name: 'locations-index' }">
@@ -42,7 +42,7 @@
           <gov-section-break size="m" />
         </gov-grid-column>
 
-        <gov-grid-column width="one-half">
+        <gov-grid-column width="one-half" v-if="!auth.isOnlyContentAdmin">
           <gov-heading size="l">Referrals</gov-heading>
           <gov-body>View and respond to referrals to your service(s).</gov-body>
           <gov-button start :to="{ name: 'referrals-index' }">
@@ -60,7 +60,7 @@
           <gov-section-break size="m" />
         </gov-grid-column>
 
-        <gov-grid-column width="one-half" v-if="auth.isOrganisationAdmin">
+        <gov-grid-column width="one-half" v-if="auth.isOrganisationAdmin()">
           <gov-heading size="l">Events</gov-heading>
           <gov-body>Add or edit events on {{ appName }}.</gov-body>
           <gov-button start :to="{ name: 'events-index' }">
@@ -69,7 +69,7 @@
           <gov-section-break size="m" />
         </gov-grid-column>
 
-        <gov-grid-column width="one-half">
+        <gov-grid-column width="one-half" v-if="!auth.isOnlyContentAdmin">
           <gov-heading size="l">Users</gov-heading>
           <gov-body>View, add and edit users in your organisation.</gov-body>
           <gov-button start :to="{ name: 'users-index' }">
@@ -87,7 +87,7 @@
           <gov-section-break size="m" />
         </gov-grid-column>
 
-        <gov-grid-column width="one-half" v-if="auth.isGlobalAdmin">
+        <gov-grid-column width="one-half" v-if="auth.isContentAdmin">
           <gov-heading size="l">Pages</gov-heading>
           <gov-body>Manage pages on the platform.</gov-body>
           <gov-button start :to="{ name: 'pages-index' }">

--- a/src/views/pages/Create.vue
+++ b/src/views/pages/Create.vue
@@ -6,10 +6,10 @@
     <gov-main-wrapper>
       <page-form
         :errors="form.$errors"
-        :is-new="true"
         :page_type.sync="form.page_type"
         :parent_id.sync="form.parent_id"
-        :title.sync="form.title"
+        @update:title="onUpdateTitle"
+        :title="form.title"
         :slug.sync="form.slug"
         :excerpt.sync="form.excerpt"
         :content.sync="form.content"
@@ -132,6 +132,10 @@ export default {
     async onSubmit() {
       await this.form.post("/pages");
       this.$router.push({ name: "pages-index" });
+    },
+    onUpdateTitle(title) {
+      this.form.title = title;
+      this.form.slug = this.slugify(title);
     },
   },
 

--- a/src/views/pages/Edit.vue
+++ b/src/views/pages/Edit.vue
@@ -9,7 +9,6 @@
         <page-form
           :page="page"
           :errors="form.$errors"
-          :is-new="false"
           :parent_id.sync="form.parent_id"
           :page_type.sync="form.page_type"
           :title.sync="form.title"
@@ -65,10 +64,10 @@ export default {
   },
   computed: {
     updateButtonText() {
-      return this.auth.isGlobalAdmin ? "Update" : "Request update";
+      return this.auth.isContentAdmin ? "Update" : "Request update";
     },
     canDelete() {
-      return this.auth.isGlobalAdmin && this.page.children.length === 0;
+      return this.auth.isContentAdmin && this.page.children.length === 0;
     },
   },
   methods: {

--- a/src/views/pages/List.vue
+++ b/src/views/pages/List.vue
@@ -42,7 +42,7 @@
           </template>
         </ck-table-filters>
       </gov-grid-column>
-      <gov-grid-column v-if="auth.isGlobalAdmin" width="one-third">
+      <gov-grid-column v-if="auth.isContentAdmin" width="one-third">
         <gov-button :to="{ name: 'pages-create-landing' }" success expand
           >Add a new Landing page</gov-button
         >
@@ -58,7 +58,7 @@
         <gov-list v-if="searching" :bullet="true">
           <li v-for="page in pages" :key="page.id">
             {{ page.title }}
-            <span v-if="auth.isGlobalAdmin">
+            <span v-if="showEdit">
               <gov-link
                 :to="{
                   name: 'pages-edit',
@@ -85,7 +85,7 @@
           @move-up="onMoveUp"
           @move-down="onMoveDown"
         >
-          <template slot="edit" slot-scope="editProps">
+          <template v-if="showEdit" slot="edit" slot-scope="editProps">
             <gov-link
               :to="{
                 name: 'pages-edit',
@@ -154,6 +154,9 @@ export default {
         params["filter[page_type]"] = this.filters.page_type;
       }
       return params;
+    },
+    showEdit() {
+      return this.auth.isContentAdmin;
     },
   },
   methods: {

--- a/src/views/pages/forms/PageForm.vue
+++ b/src/views/pages/forms/PageForm.vue
@@ -30,7 +30,7 @@
       label="Unique slug"
       type="text"
       :error="errors.get('slug')"
-      v-if="auth.isGlobalAdmin"
+      v-if="auth.isContentAdmin"
     >
       <gov-hint slot="hint" for="slug">
         This will be used to access the page.<br />
@@ -103,11 +103,6 @@ export default {
     errors: {
       type: Object,
       required: true,
-    },
-    isNew: {
-      required: false,
-      type: Boolean,
-      default: false,
     },
     parent_id: {
       required: true,
@@ -213,11 +208,6 @@ export default {
     onInput(field, value) {
       this.$emit(`update:${field}`, value);
       this.$emit("clear", field);
-
-      if (this.auth.isGlobalAdmin && field === "title" && this.isNew) {
-        this.$emit("update:slug", this.slugify(value));
-        this.$emit("clear", "slug");
-      }
     },
     async fetchPages() {
       this.loading = true;

--- a/src/views/users/Create.vue
+++ b/src/views/users/Create.vue
@@ -70,6 +70,7 @@ export default {
             // Delete the organisation and service IDs instead of sending null values.
             case "Super Admin":
             case "Global Admin":
+            case "Content Admin":
               delete role.organisation_id;
               delete role.service_id;
               break;

--- a/src/views/users/Edit.vue
+++ b/src/views/users/Edit.vue
@@ -155,6 +155,7 @@ export default {
             // Delete the organisation and service IDs instead of sending null values.
             case "Super Admin":
             case "Global Admin":
+            case "Content Admin":
               delete role.organisation_id;
               delete role.service_id;
               break;

--- a/src/views/users/Index.vue
+++ b/src/views/users/Index.vue
@@ -122,7 +122,7 @@
               {
                 heading: 'Highest permission level',
                 sort: 'highest_role',
-                render: (user) => displayHighestRole(user.roles),
+                render: (user) => auth.displayHighestRole(user.roles),
               },
               { heading: 'Phone number', render: (user) => user.phone },
             ]"
@@ -142,6 +142,7 @@
 </template>
 
 <script>
+import Auth from "@/classes/Auth";
 import CkResourceListingTable from "@/components/Ck/CkResourceListingTable.vue";
 import CkTableFilters from "@/components/Ck/CkTableFilters.vue";
 
@@ -150,6 +151,7 @@ export default {
   components: { CkResourceListingTable, CkTableFilters },
   data() {
     return {
+      auth: Auth,
       filters: {
         first_name: "",
         last_name: "",
@@ -159,14 +161,6 @@ export default {
         at_organisation: "",
         at_service: "",
       },
-      roles: [
-        { value: "", text: "All" },
-        { value: "Super Admin", text: "Super Admin" },
-        { value: "Global Admin", text: "Global Admin" },
-        { value: "Organisation Admin", text: "Organisation Admin" },
-        { value: "Service Admin", text: "Service Admin" },
-        { value: "Service Worker", text: "Service Worker" },
-      ],
       loadingOrganisations: false,
       organisations: [],
       loadingServices: false,
@@ -174,6 +168,9 @@ export default {
     };
   },
   computed: {
+    roles() {
+      return Auth.roles.slice().unshift({ value: "", text: "All" });
+    },
     params() {
       const params = {
         include: "user-roles",
@@ -232,39 +229,6 @@ export default {
     },
     onAddUser() {
       this.$router.push({ name: "users-create" });
-    },
-    displayHighestRole(roles) {
-      const isSuperAdmin =
-        roles.find((role) => role.role === "Super Admin") !== undefined;
-      if (isSuperAdmin) {
-        return "Super Admin";
-      }
-
-      const isGlobalAdmin =
-        roles.find((role) => role.role === "Global Admin") !== undefined;
-      if (isGlobalAdmin) {
-        return "Global Admin";
-      }
-
-      const isOrganisationAdmin =
-        roles.find((role) => role.role === "Organisation Admin") !== undefined;
-      if (isOrganisationAdmin) {
-        return "Organisation Admin";
-      }
-
-      const isServiceAdmin =
-        roles.find((role) => role.role === "Service Admin") !== undefined;
-      if (isServiceAdmin) {
-        return "Service Admin";
-      }
-
-      const isServiceWorker =
-        roles.find((role) => role.role === "Service Worker") !== undefined;
-      if (isServiceWorker) {
-        return "Service Worker";
-      }
-
-      return "None";
     },
     async fetchOrganisations() {
       this.loadingOrganisations = true;

--- a/src/views/users/forms/UserForm.vue
+++ b/src/views/users/forms/UserForm.vue
@@ -51,6 +51,10 @@
 
     <gov-list bullet>
       <li>
+        <strong>Content admins:</strong>
+        Add pages, edit pages and remove pages
+      </li>
+      <li>
         <strong>Organisation admins:</strong>
         Add services, add users, edit services, edit users, manage referrals
       </li>


### PR DESCRIPTION
### Summary
https://app.shortcut.com/helpyourselfsutton/story/2755/create-a-new-content-admin-user-role

- Changed permissions for creating, editing and deleting pages so only content admin (and super admin) are allowed
- Prevent all users except content admins from accessing the pages area
- Prevented content admin from accessing other areas of the admin

### Development checklist
- [ ] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
