### PR TITLE
Added homepage property to collection update on reorder

### DIFF
--- a/src/views/admin/index/collections/Categories.vue
+++ b/src/views/admin/index/collections/Categories.vue
@@ -96,6 +96,7 @@ export default {
         icon: collection.icon,
         order: collection.order,
         enabled: collection.enabled,
+        homepage: collection.homepage,
         sideboxes: collection.sideboxes,
         category_taxonomies: collection.category_taxonomies.map(
           (taxonomy) => taxonomy.id


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/3298/reordering-homepage-collections-fails

- Collection update when re-ordering was failing due to missing required homepage property
- Added homepage property to collection object when updating order

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
