### PR TITLE
Removed unnecesary auth check from page slug field

### DIFF
--- a/src/views/pages/forms/PageForm.vue
+++ b/src/views/pages/forms/PageForm.vue
@@ -30,7 +30,6 @@
       label="Unique slug"
       type="text"
       :error="errors.get('slug')"
-      v-if="auth.isContentAdmin"
     >
       <gov-hint slot="hint" for="slug">
         This will be used to access the page.<br />


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/3551/slug-and-excerpt-fields-are-randomly-being-hidden-for-super-admins

- Removed unnecessary auth check from page slug field

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
