### PR TITLE
Fixed display of roles in user search filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 node_modules
 /dist
-
+/src/assets/*
 /tests/e2e/reports/
 selenium-debug.log
 

--- a/src/views/users/Index.vue
+++ b/src/views/users/Index.vue
@@ -142,7 +142,6 @@
 </template>
 
 <script>
-import Auth from "@/classes/Auth";
 import CkResourceListingTable from "@/components/Ck/CkResourceListingTable.vue";
 import CkTableFilters from "@/components/Ck/CkTableFilters.vue";
 
@@ -151,7 +150,6 @@ export default {
   components: { CkResourceListingTable, CkTableFilters },
   data() {
     return {
-      auth: Auth,
       filters: {
         first_name: "",
         last_name: "",
@@ -169,7 +167,9 @@ export default {
   },
   computed: {
     roles() {
-      return Auth.roles.slice().unshift({ value: "", text: "All" });
+      const roles = this.auth.roles.slice();
+      roles.splice(0, 0, { text: "All", value: "" });
+      return roles;
     },
     params() {
       const params = {


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/3625/role-dropdown-empty-on-users-filter

- Roles dropdown was not displaying roles in user search filter
- Updated to use new auth object

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
