### PR TITLE
Replaced out of scope reference in register views

### DIFF
--- a/src/views/register/Index.vue
+++ b/src/views/register/Index.vue
@@ -18,7 +18,7 @@
 import Form from "@/classes/Form";
 import axios from "axios";
 const http = axios.create({
-  baseURL: `${this.appApiUri}/core/v1`
+  baseURL: `${process.env.VUE_APP_API_URI}/core/v1`
 });
 http.defaults.headers.post["Content-Type"] = "application/json";
 

--- a/src/views/register/forms/OrganisationSearch.vue
+++ b/src/views/register/forms/OrganisationSearch.vue
@@ -37,7 +37,7 @@
 import axios from "axios";
 
 const http = axios.create({
-  baseURL: `${this.appApiUri}/core/v1`
+  baseURL: `${process.env.VUE_APP_API_URI}/core/v1`
 });
 http.defaults.headers.post["Content-Type"] = "application/json";
 

--- a/src/views/register/new/Register.vue
+++ b/src/views/register/new/Register.vue
@@ -27,7 +27,7 @@ import Form from "@/classes/Form";
 import axios from "axios";
 
 const http = axios.create({
-  baseURL: `${this.appApiUri}/core/v1`
+  baseURL: `${process.env.VUE_APP_API_URI}/core/v1`
 });
 http.defaults.headers.post["Content-Type"] = "application/json";
 


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/3639/register-page-isn-t-working-in-the-sutton-admin-app

- Reference to `this` in register views is out of scope so replaced with `process.env` variable
- Repeat of previous commit `9673b81` which was overwritten

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
