### PR TITLE
Only show orgs or services a user can manage in user roles [3256]

### DIFF
--- a/src/views/service-locations/Show.vue
+++ b/src/views/service-locations/Show.vue
@@ -25,7 +25,7 @@
 
             <service-location-details :service-location="serviceLocation" />
 
-            <template v-if="auth.isServiceAdmin(serviceLocation.service)">
+            <template v-if="auth.isServiceAdmin(serviceLocation.service.id)">
               <gov-body
                 >Please be certain of the action before deleting a service
                 location</gov-body
@@ -41,7 +41,7 @@
             </template>
           </gov-grid-column>
           <gov-grid-column
-            v-if="auth.isServiceAdmin(serviceLocation.service)"
+            v-if="auth.isServiceAdmin(serviceLocation.service.id)"
             width="one-third"
             class="text-right"
           >

--- a/src/views/services/show/DetailsTab.vue
+++ b/src/views/services/show/DetailsTab.vue
@@ -81,7 +81,7 @@
           <gov-table-header top scope="row">Last updated</gov-table-header>
           <gov-table-cell>
             {{ service.last_modified_at | lastModifiedAt }}
-            <template v-if="auth.isServiceAdmin(service)">
+            <template v-if="auth.isServiceAdmin(service.id)">
               <gov-link
                 v-if="!refreshForm.$submitting"
                 @click="onMarkAsStillUpToDate"

--- a/src/views/services/show/LocationsTab.vue
+++ b/src/views/services/show/LocationsTab.vue
@@ -7,7 +7,7 @@
         >
       </gov-grid-column>
       <gov-grid-column
-        v-if="auth.isServiceAdmin(service)"
+        v-if="auth.isServiceAdmin(service.id)"
         width="one-third text-right"
       >
         <gov-button


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/3256/add-users-can-see-whole-list

- Organisation and service admins can only view organisations that they have admin rights in when assigning roles to users
- Service admins can only view services that they have admin rights in when assigning roles to users

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
