### PR TITLE
Allow events to start in the past but must end in the future

### DIFF
--- a/src/views/events/forms/DetailsTab.vue
+++ b/src/views/events/forms/DetailsTab.vue
@@ -37,7 +37,6 @@
     <ck-date-picker
       id="start_date"
       :value="start_date"
-      :min="todayAsDate"
       :max="end_date"
       :required="true"
       :error="errors.get('start_date')"
@@ -48,7 +47,7 @@
     <ck-date-picker
       id="end_date"
       :value="end_date"
-      :min="start_date"
+      :min="earliestEndDate"
       :required="true"
       :error="errors.get('end_date')"
       @input="onInput('end_date', $event)"
@@ -443,11 +442,20 @@ export default {
       ];
     },
     todayAsDate() {
-      const now = new Date();
-      return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(
-        2,
-        "0"
-      )}-${String(now.getDate()).padStart(2, "0")}`;
+      return this.dateToDateString(new Date());
+    },
+    earliestEndDate() {
+      if (!this.start_date) {
+        return this.todayAsDate;
+      }
+      const startDate = new Date(this.start_date);
+      const today = new Date();
+      today.setHours(0);
+      today.setMinutes(0);
+      today.setSeconds(0);
+      return today < startDate
+        ? this.dateToDateString(startDate)
+        : this.dateToDateString(today);
     }
   },
 
@@ -455,6 +463,11 @@ export default {
     onInput(field, value) {
       this.$emit(`update:${field}`, value);
       this.$emit("clear", field);
+    },
+    dateToDateString(dateObj) {
+      return `${dateObj.getFullYear()}-${String(
+        dateObj.getMonth() + 1
+      ).padStart(2, "0")}-${String(dateObj.getDate()).padStart(2, "0")}`;
     }
   },
 


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/3332/remove-validation-from-events-so-start-date-can-be-in-the-past

- Remove limit that events must start in the future
- Added limit that events must end in the future and after the start date

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
