### PR TITLE
Added Taxonomies tab to Show Service

### DIFF
--- a/src/components/Ck/CkTaxonomyInput.vue
+++ b/src/components/Ck/CkTaxonomyInput.vue
@@ -66,7 +66,7 @@ export default {
       type: Boolean,
       default: false
     },
-    hierarchy: {
+    showCollections: {
       required: false,
       type: Boolean,
       default: true
@@ -113,11 +113,14 @@ export default {
       this.loading = true;
       const { data: taxonomies } = await http.get(`/taxonomies/${this.root}`);
       this.taxonomies = taxonomies.data;
-      const { data: collections } = await http.get(
-        `/collections/${this.root}/all`
-      );
       this.setFlattenedTaxonomies();
-      this.setTaxonomyCollections(collections.data);
+
+      if (this.showCollections) {
+        const { data: collections } = await http.get(
+          `/collections/${this.root}/all`
+        );
+        this.setTaxonomyCollections(collections.data);
+      }
       this.loading = false;
     },
     setFlattenedTaxonomies(taxonomies = null) {

--- a/src/components/Ck/CkTaxonomyList.vue
+++ b/src/components/Ck/CkTaxonomyList.vue
@@ -30,6 +30,8 @@
         :filteredTaxonomyIds="filteredTaxonomyIds"
         :taxonomyCollections="taxonomyCollections"
         :checkbox="false"
+        :edit="edit"
+        :bullet="bullet"
         @moveUp="$emit('move-up', $event)"
         @moveDown="$emit('move-down', $event)"
       />

--- a/src/router.js
+++ b/src/router.js
@@ -238,6 +238,11 @@ let router = new Router({
           path: "referral",
           name: "services-show-referral",
           component: () => import("@/views/services/show/ReferralTab")
+        },
+        {
+          path: "taxonomies",
+          name: "services-show-taxonomies",
+          component: () => import("@/views/services/show/TaxonomiesTab")
         }
       ]
     },

--- a/src/views/collections/categories/forms/CollectionForm.vue
+++ b/src/views/collections/categories/forms/CollectionForm.vue
@@ -80,7 +80,7 @@
       @input="$emit('update:category_taxonomies', $event)"
       :error="errors.get('category_taxonomies')"
       @clear="$emit('clear', 'category_taxonomies')"
-      :hierarchy="false"
+      :showCollections="false"
     />
   </div>
 </template>

--- a/src/views/collections/events/forms/CollectionForm.vue
+++ b/src/views/collections/events/forms/CollectionForm.vue
@@ -72,7 +72,7 @@
       @input="$emit('update:category_taxonomies', $event)"
       :error="errors.get('category_taxonomies')"
       @clear="$emit('clear', 'category_taxonomies')"
-      :hierarchy="false"
+      :showCollections="false"
     />
   </div>
 </template>

--- a/src/views/collections/personas/forms/CollectionForm.vue
+++ b/src/views/collections/personas/forms/CollectionForm.vue
@@ -85,7 +85,7 @@
       @input="$emit('update:category_taxonomies', $event)"
       :error="errors.get('category_taxonomies')"
       @clear="$emit('clear', 'category_taxonomies')"
-      :hierarchy="false"
+      :showCollections="false"
     />
   </div>
 </template>

--- a/src/views/services/Show.vue
+++ b/src/views/services/Show.vue
@@ -84,8 +84,18 @@ export default {
           heading: "Eligibility",
           to: { name: "services-show-eligibility" }
         },
-        { heading: "Locations", to: { name: "services-show-locations" } },
-        { heading: "Referral", to: { name: "services-show-referral" } }
+        {
+          heading: "Locations",
+          to: { name: "services-show-locations" }
+        },
+        {
+          heading: "Referral",
+          to: { name: "services-show-referral" }
+        },
+        {
+          heading: "Taxonomies",
+          to: { name: "services-show-taxonomies" }
+        }
       ]
     };
   },

--- a/src/views/services/show/TaxonomiesTab.vue
+++ b/src/views/services/show/TaxonomiesTab.vue
@@ -1,0 +1,83 @@
+<template>
+  <div>
+    <gov-heading size="l">Taxonomies</gov-heading>
+
+    <gov-section-break size="l" />
+
+    <gov-grid-row>
+      <gov-grid-column width="two-thirds">
+        <ck-taxonomy-list
+          :taxonomies="taxonomies"
+          :filteredTaxonomyIds="serviceTaxonomyIds"
+          :taxonomyCollections="taxonomyCollections"
+          :bullet="true"
+          v-if="!loading"
+        />
+      </gov-grid-column>
+    </gov-grid-row>
+  </div>
+</template>
+
+<script>
+import http from "@/http";
+import CkTaxonomyList from "@/components/Ck/CkTaxonomyList";
+export default {
+  name: "TaxonomiesTab",
+
+  components: {
+    CkTaxonomyList
+  },
+
+  props: {
+    service: {
+      type: Object,
+      required: true
+    }
+  },
+
+  data() {
+    return {
+      loading: false,
+      taxonomies: [],
+      taxonomyCollections: {}
+    };
+  },
+
+  computed: {
+    serviceTaxonomyIds() {
+      return this.service.category_taxonomies.map(taxonomy => taxonomy.id);
+    }
+  },
+
+  methods: {
+    async fetchTaxonomies() {
+      this.loading = true;
+
+      const { data: taxonomies } = await http.get("/taxonomies/categories");
+      this.taxonomies = taxonomies.data;
+      const { data: collections } = await http.get(
+        "/collections/categories/all"
+      );
+      this.setTaxonomyCollections(collections.data);
+
+      this.loading = false;
+    },
+
+    setTaxonomyCollections(collections) {
+      collections.forEach(collection => {
+        collection.category_taxonomies.forEach(taxonomy => {
+          this.taxonomyCollections[taxonomy.id] =
+            this.taxonomyCollections[taxonomy.id] || [];
+          this.taxonomyCollections[taxonomy.id].push(collection.name);
+        });
+      });
+    }
+  },
+
+  created() {
+    this.fetchTaxonomies();
+  }
+};
+</script>
+
+<style lang="scss" scoped></style>


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/3344/display-list-of-service-taxonomies

- Added Taxonomies tab to show Service page
- Display list of service taxonomies together with the collections they are in

### Development checklist
- [ ] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
