### PR TITLE
Added UI for page video content

### DIFF
--- a/src/components/Ck/CkVideoEmbed.vue
+++ b/src/components/Ck/CkVideoEmbed.vue
@@ -1,0 +1,55 @@
+<template>
+  <div>
+    <gov-heading tag="h4" size="s">Video Embed</gov-heading>
+    <gov-error-message v-if="error !== null" v-text="error" :for="id" />
+    <ck-text-input
+      :value="video.title"
+      @input="onInput('title', $event)"
+      id="video_title"
+      label="Title"
+      type="text"
+      :error="null"
+    />
+    <ck-text-input
+      :value="video.url"
+      @input="onInput('url', $event)"
+      id="video_url"
+      label="Video URL"
+      type="url"
+      :error="null"
+    >
+      <template slot="hint">
+        <gov-hint for="video_embed">
+          Youtube and Vimeo links are accepted.
+        </gov-hint>
+      </template>
+    </ck-text-input>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "VideoEmbed",
+
+  props: {
+    error: {
+      required: true
+    },
+    video: {
+      type: Object,
+      required: true
+    }
+  },
+
+  methods: {
+    onInput(field, value) {
+      const video = Object.assign({}, this.video);
+      video[field] = value;
+      this.$emit("input", video);
+      this.$emit("clear", "video");
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/components/Ck/CkVideoIframe.vue
+++ b/src/components/Ck/CkVideoIframe.vue
@@ -2,24 +2,26 @@
   <iframe
     :width="computedWidth"
     :height="computedHeight"
-    :src="src"
+    :src="videoSrc"
     :title="title"
     frameborder="0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
     allowfullscreen
+    @load="computeSize"
   ></iframe>
 </template>
 
 <script>
 export default {
+  name: "CkVideoIframe",
   props: {
     width: {
-      type: Number,
-      required: true
+      type: [String, Number],
+      default: 560
     },
     height: {
-      type: Number,
-      required: true
+      type: [String, Number],
+      default: 315
     },
     src: {
       type: String,
@@ -41,6 +43,15 @@ export default {
   computed: {
     aspectRatio() {
       return this.height / this.width;
+    },
+    videoSrc() {
+      const src = String(this.src);
+      if (src.startsWith("https://www.youtube.com")) {
+        return src.replace("watch?v=", "embed/");
+      } else if (src.startsWith("https://vimeo.com")) {
+        return src.replace("vimeo.com", "player.vimeo.com/video");
+      }
+      return this.src;
     }
   },
   methods: {
@@ -56,11 +67,14 @@ export default {
       const bottomPad = parseInt(style.paddingBottom) || 0;
       this.computedHeight =
         this.computedWidth * this.aspectRatio - topPad - bottomPad;
+    },
+    computeSize() {
+      this.computeWidth();
+      this.computeHeight();
     }
   },
   mounted() {
-    this.computeWidth();
-    this.computeHeight();
+    this.computeSize();
   }
 };
 </script>

--- a/src/components/CkPageContent.vue
+++ b/src/components/CkPageContent.vue
@@ -33,11 +33,21 @@
           @input="onChangeCalltoAction(sectionId, index, $event)"
           :error="errors.get(`content.${sectionId}.content.${index}`)"
         />
+        <ck-video-embed
+          v-else-if="content.type === 'video'"
+          :video="content"
+          :id="`${sectionId}-video-${index}`"
+          @input="onChangeVideo(sectionId, index, $event)"
+          :error="errors.get(`content.${sectionId}.content.${index}`)"
+        />
         <gov-button type="button" @click="addCopy(sectionId, index)"
           >Add Copy here</gov-button
         >&nbsp;
         <gov-button type="button" @click="addCallToAction(sectionId, index)"
           >Add Call to action here</gov-button
+        >&nbsp;
+        <gov-button type="button" @click="addVideo(sectionId, index)"
+          >Add Video here</gov-button
         >&nbsp;
         <span v-if="index > 0">
           <gov-button
@@ -63,12 +73,14 @@
 
 <script>
 import CkCallToAction from "./Ck/CkCallToAction";
+import CkVideoEmbed from "./Ck/CkVideoEmbed.vue";
 
 export default {
   name: "PageContent",
 
   components: {
-    CkCallToAction
+    CkCallToAction,
+    CkVideoEmbed
   },
 
   props: {
@@ -132,6 +144,14 @@ export default {
       this.$emit("update", content);
       this.$emit("clear", `content_${section}_content`);
     },
+    onChangeVideo(section, index, video) {
+      const content = Object.assign({}, this.content);
+
+      content[section]["content"][index] = video;
+
+      this.$emit("update", content);
+      this.$emit("clear", `content_${section}_content`);
+    },
     addCopy(section, index) {
       const content = Object.assign({}, this.content);
 
@@ -152,6 +172,18 @@ export default {
         description: "",
         url: "",
         buttonText: ""
+      });
+
+      this.$emit("update", content);
+      this.$emit("clear", `content_${section}_content`);
+    },
+    addVideo(section, index) {
+      const content = Object.assign({}, this.content);
+
+      content[section]["content"].splice(index + 1, 0, {
+        type: "video",
+        title: "",
+        url: ""
       });
 
       this.$emit("update", content);

--- a/src/views/help/Index.vue
+++ b/src/views/help/Index.vue
@@ -19,7 +19,7 @@
                 :key="`video-${j}`"
                 width="one-half"
               >
-                <video-iframe
+                <ck-video-iframe
                   :height="video.height"
                   :width="video.width"
                   :src="video.src"
@@ -36,13 +36,13 @@
 </template>
 
 <script>
-import VideoIframe from "./components/VideoIframe";
+import CkVideoIframe from "@/components/Ck/CkVideoIframe";
 
 export default {
   name: "Help",
 
   components: {
-    VideoIframe
+    CkVideoIframe
   },
 
   data() {

--- a/src/views/pages/show/PageContent.vue
+++ b/src/views/pages/show/PageContent.vue
@@ -28,6 +28,17 @@
               <gov-button>{{ contentItem.buttonText }}</gov-button>
               <gov-hint>Link to: {{ contentItem.url }}</gov-hint>
             </div>
+            <div v-if="contentItem.type === 'video'">
+              <gov-heading v-if="contentItem.title" size="s" tag="h3">{{
+                contentItem.title
+              }}</gov-heading>
+              <ck-video-iframe
+                height="315"
+                width="560"
+                :src="contentItem.url"
+                :title="contentItem.title"
+              />
+            </div>
           </div>
         </gov-table-cell>
       </gov-table-row>
@@ -36,6 +47,8 @@
 </template>
 
 <script>
+import CkVideoIframe from "@/components/Ck/CkVideoIframe";
+
 export default {
   name: "PageContent",
 
@@ -44,6 +57,10 @@ export default {
       type: Object,
       required: true
     }
+  },
+
+  components: {
+    CkVideoIframe
   },
 
   computed: {


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/3308/allow-videos-to-be-embeded-within-page-content

- Added UI for page content videos

### Development checklist
- [ ] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
