### PR TITLE
Fixed issue preventing login when roles and services mismatch

### DIFF
--- a/src/classes/Auth.js
+++ b/src/classes/Auth.js
@@ -108,7 +108,7 @@ class Auth {
         const service = services.data.data.find(
           service => service.id === role.service_id
         );
-        role.organisation_id = service.organisation_id;
+        role.organisation_id = service ? service.organisation_id : null;
       }
     });
 


### PR DESCRIPTION
### Summary
- Hotfix for issue preventing login when services assigned to a user through a role and the list of services mismatch. Essentially an issue with dirty data, but should be accommodated for.

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
