### PR TITLE
Corrected service score equality check on edit

### DIFF
--- a/src/classes/Auth.js
+++ b/src/classes/Auth.js
@@ -396,27 +396,27 @@ class Auth {
    * @param {string} type
    * @returns {boolean}
    */
-  canEdit(type, model = null) {
+  canEdit(type, modelId = null) {
     if (this.isSuperAdmin) {
       return true;
     }
     if (type === "event") {
-      return this.isOrganisationAdmin(model);
+      return this.isOrganisationAdmin(modelId);
     }
     if (type === "service") {
-      return this.isServiceAdmin(model);
+      return this.isServiceAdmin(modelId);
     }
     if (type === "organisation") {
-      return this.isOrganisationAdmin(model);
+      return this.isOrganisationAdmin(modelId);
     }
     if (type === "location") {
-      return this.isServiceAdmin(model);
+      return this.isServiceAdmin(modelId);
     }
     if (type === "page") {
       return this.isContentAdmin;
     }
     if (type === "referral") {
-      return this.isServiceWorker(model) && !this.isOnlyGlobalAdmin;
+      return this.isServiceWorker(modelId) && !this.isOnlyGlobalAdmin;
     }
     if (type === "user") {
       return (

--- a/src/views/services/Edit.vue
+++ b/src/views/services/Edit.vue
@@ -369,7 +369,10 @@ export default {
           if (data.status === this.service.status) {
             delete data.status;
           }
-          if (data.score === this.service.score) {
+          if (
+            data.score === this.service.score ||
+            (!data.score && !this.service.score)
+          ) {
             delete data.score;
           }
           if (data.intro === this.service.intro) {

--- a/src/views/services/Show.vue
+++ b/src/views/services/Show.vue
@@ -21,7 +21,7 @@
               >
             </gov-grid-column>
             <gov-grid-column
-              v-if="auth.canEdit('service', service)"
+              v-if="auth.canEdit('service', service.id)"
               width="one-third"
               class="text-right"
             >
@@ -99,6 +99,7 @@ export default {
       ]
     };
   },
+
   methods: {
     async fetchService() {
       this.loading = true;


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/3876/quality-score-field-appearing-in-an-update-request-even-when-no-change-has-been-made-to-that-field

- Fixed check for equality on `service.score` when comparing empty string to null
- Fixed permission on 'Edit Service' button

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
