### PR TITLE
Set char limit on service useful info description to 1000

### DIFF
--- a/src/views/services/inputs/UsefulInfosInput.vue
+++ b/src/views/services/inputs/UsefulInfosInput.vue
@@ -19,7 +19,7 @@
         :id="`useful_infos.${index}.description`"
         label="Description"
         hint="Provide detail to the title above. For example, if you picked ‘Parking’ you might say “There is no parking available on site, however there is pay and display opposite”."
-        :maxlength="150"
+        :maxlength="1000"
         :error="errors.get(`useful_infos.${index}.description`)"
         :extensions="extensions"
       />
@@ -132,7 +132,10 @@ export default {
             usefulInfos.find(
               usefulInfo => usefulInfo.title === usefulInfoTitleOption.value
             ) !== undefined;
-          const newOption = { ...usefulInfoTitleOption, disabled: hasBeenUsed };
+          const newOption = {
+            ...usefulInfoTitleOption,
+            disabled: hasBeenUsed
+          };
           this.$set(this.usefulInfoTitleOptions, index, newOption);
         });
       },


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/3906/character-limit-on-good-to-know

- Set max characters for UsefulInfo.description to 1000

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
