### PR TITLE
Bug/sc 3258/introduce password guidance when adding editing

### DIFF
--- a/src/components/Ck/CkPassword.vue
+++ b/src/components/Ck/CkPassword.vue
@@ -1,0 +1,53 @@
+<template>
+  <ck-text-input
+    :value="value"
+    :id="id"
+    :label="label"
+    :type="type"
+    hint="The password must be at least eight characters long, contain one uppercase letter, one lowercase letter, one number and one special character (!#$%&()*+,-./:;<=>?@[]^_`{|}~)"
+    :error="error"
+    @input="$emit('input', $event)"
+  >
+    <template v-slot:after-input>
+      <GovButton type="button" @click="toggleShowPassword"
+        >Show Password</GovButton
+      >
+    </template>
+  </ck-text-input>
+</template>
+
+<script>
+export default {
+  name: "CkPassword",
+  props: {
+    value: {
+      type: String,
+      required: true
+    },
+    id: {
+      type: String,
+      default: "password"
+    },
+    label: {
+      type: String,
+      default: "Password"
+    },
+    error: {
+      type: String,
+      default: null
+    }
+  },
+  data() {
+    return {
+      type: "password"
+    };
+  },
+  methods: {
+    toggleShowPassword() {
+      this.type = this.type === "password" ? "text" : "password";
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/components/Ck/CkPassword.vue
+++ b/src/components/Ck/CkPassword.vue
@@ -9,9 +9,9 @@
     @input="$emit('input', $event)"
   >
     <template v-slot:after-input>
-      <GovButton type="button" @click="toggleShowPassword"
-        >Show Password</GovButton
-      >
+      <GovButton type="button" @click="toggleShowPassword">{{
+        toggleShowPasswordText
+      }}</GovButton>
     </template>
   </ck-text-input>
 </template>
@@ -41,6 +41,11 @@ export default {
     return {
       type: "password"
     };
+  },
+  computed: {
+    toggleShowPasswordText() {
+      return this.type === "password" ? "Show Password" : "Hide Password";
+    }
   },
   methods: {
     toggleShowPassword() {

--- a/src/views/register/forms/UserAccount.vue
+++ b/src/views/register/forms/UserAccount.vue
@@ -52,6 +52,7 @@
       id="password"
       label="Password"
       type="password"
+      hint="The password must be at least eight characters long, contain one uppercase letter, one lowercase letter, one number and one special character (!#$%&()*+,-./:;<=>?@[]^_`{|}~)"
       :error="errors.get('user.password')"
     />
   </div>

--- a/src/views/register/forms/UserAccount.vue
+++ b/src/views/register/forms/UserAccount.vue
@@ -47,19 +47,22 @@
       :error="errors.get('user.phone')"
     />
 
-    <ck-text-input
+    <ck-password
       v-model="form.user.password"
       id="password"
       label="Password"
-      type="password"
-      hint="The password must be at least eight characters long, contain one uppercase letter, one lowercase letter, one number and one special character (!#$%&()*+,-./:;<=>?@[]^_`{|}~)"
       :error="errors.get('user.password')"
     />
   </div>
 </template>
 
 <script>
+import CkPassword from "@/components/Ck/CkPassword.vue";
 export default {
+  components: {
+    CkPassword
+  },
+
   props: {
     form: {
       type: Object,

--- a/src/views/users/forms/UserForm.vue
+++ b/src/views/users/forms/UserForm.vue
@@ -36,13 +36,11 @@
       :error="errors.get('phone')"
     />
 
-    <ck-text-input
+    <ck-password
       :value="password"
       @input="onInput('password', $event)"
       id="password"
       label="Password"
-      type="password"
-      hint="The password must be at least eight characters long, contain one uppercase letter, one lowercase letter, one number and one special character (!#$%&()*+,-./:;<=>?@[]^_`{|}~)"
       :error="errors.get('password')"
     />
 
@@ -80,10 +78,14 @@
 
 <script>
 import UserRolesInput from "@/views/users/inputs/UserRolesInput";
+import CkPassword from "@/components/Ck/CkPassword.vue";
 
 export default {
   name: "UserForm",
-  components: { UserRolesInput },
+  components: {
+    UserRolesInput,
+    CkPassword
+  },
   props: {
     errors: {
       required: true,

--- a/src/views/users/forms/UserForm.vue
+++ b/src/views/users/forms/UserForm.vue
@@ -42,6 +42,7 @@
       id="password"
       label="Password"
       type="password"
+      hint="The password must be at least eight characters long, contain one uppercase letter, one lowercase letter, one number and one special character (!#$%&()*+,-./:;<=>?@[]^_`{|}~)"
       :error="errors.get('password')"
     />
 


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/3258/introduce-password-guidance-when-adding-editing-users

- Added help text to describe what is required for a password to pass validation
- Added a show/hide password button
- Refactored into specialist password component

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
