### PR TITLE
Allow empty email and phone fields on organisation registration

### DIFF
--- a/src/views/register/new/Organisation.vue
+++ b/src/views/register/new/Organisation.vue
@@ -82,7 +82,7 @@ export default {
   computed: {
     fieldsEmpty() {
       return Object.entries(this.form.organisation).some(([field, value]) => {
-        return !["id", "slug"].includes(field) && value == "";
+        return !["id", "slug", "phone", "email"].includes(field) && value == "";
       });
     }
   }


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/3941/org-phone-required-on-public-registration

- Removed requirement for non-empty email and phone fields on organisation registration form

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
