### PR TITLE
Added character count bar to description wysiwyg fields

### DIFF
--- a/src/components/Ck/CkCharacterCountBar.vue
+++ b/src/components/Ck/CkCharacterCountBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="ck-character-bar-container">
+  <div class="ck-character-bar-container" :title="`${count} / ${maxLength}`">
     <div
       class="ck-character-bar"
       :style="{ backgroundColor: barColour, width: barWidthStyle }"
@@ -54,7 +54,7 @@ export default {
   @extend .govuk-body;
 
   margin: 0;
-  color: $govuk-secondary-text-colour;
+  background-color: $govuk-border-colour;
 }
 .ck-character-bar {
   padding-top: 0.5rem;

--- a/src/views/events/forms/DetailsTab.vue
+++ b/src/views/events/forms/DetailsTab.vue
@@ -84,7 +84,7 @@
       "
       :error="errors.get('description')"
       large
-      :maxlength="3000"
+      :maxlength="10000"
     />
 
     <ck-radio-input

--- a/src/views/organisations/forms/OrganisationForm.vue
+++ b/src/views/organisations/forms/OrganisationForm.vue
@@ -28,6 +28,7 @@
       :value="description"
       @input="onInput('description', $event)"
       id="description"
+      :maxlength="10000"
       label="Please provide a one-line summary of organisation"
       hint="This should be a short line or two that summarises who the organisation is and will appear below the Organisation name on it's page."
       :error="errors.get('description')"

--- a/src/views/register/new/Organisation.vue
+++ b/src/views/register/new/Organisation.vue
@@ -27,6 +27,7 @@
     <ck-wysiwyg-input
       v-model="form.organisation.description"
       id="description"
+      :maxlength="10000"
       label="Please provide a one-line summary of organisation"
       hint="This should be a short line or two that summarises who the organisation is and will appear below the Organisation name on it's page."
       :error="errors.get('organisation.description')"


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/4099/increase-event-description-char-limit-to-10k

- Added character count bar to WYSIWYG organisation description field
- Added character count bar to WYSIWYG service description field
- Added character count bar to WYSIWYG organisation event description field

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
