### PR TITLE
Add approve and edit button to update requests

### DIFF
--- a/src/views/locations/forms/LocationForm.vue
+++ b/src/views/locations/forms/LocationForm.vue
@@ -191,7 +191,6 @@ export default {
       type: Boolean
     },
     image_file_id: {
-      required: true,
       type: String
     },
     id: {

--- a/src/views/pages/Edit.vue
+++ b/src/views/pages/Edit.vue
@@ -113,7 +113,10 @@ export default {
           }
 
           // Remove the image from the request if unchanged.
-          if (this.page.image && data.image_file_id === this.page.image.id) {
+          if (
+            (this.page.image && data.image_file_id === this.page.image.id) ||
+            (this.page.image === null && data.image_file_id === null)
+          ) {
             delete data.image_file_id;
           }
 

--- a/src/views/services/Edit.vue
+++ b/src/views/services/Edit.vue
@@ -484,7 +484,11 @@ export default {
           }
 
           // Remove the logo from the request if null, or delete if false.
-          if (data.logo_file_id === null) {
+          if (
+            (this.service.image &&
+              this.service.image.id === data.logo_file_id) ||
+            (this.service.image === null && data.logo_file_id === null)
+          ) {
             delete data.logo_file_id;
           } else if (data.logo_file_id === false) {
             data.logo_file_id = null;

--- a/src/views/update-requests/show/LocationDetails.vue
+++ b/src/views/update-requests/show/LocationDetails.vue
@@ -91,6 +91,18 @@
           }}</gov-table-cell>
         </gov-table-row>
 
+        <gov-table-row v-if="location.hasOwnProperty('has_accessible_toilet')">
+          <gov-table-header top scope="row"
+            >Has accessible toilet</gov-table-header
+          >
+          <gov-table-cell>{{
+            original.has_accessible_toilet ? "Yes" : "No"
+          }}</gov-table-cell>
+          <gov-table-cell>{{
+            location.has_accessible_toilet ? "Yes" : "No"
+          }}</gov-table-cell>
+        </gov-table-row>
+
         <gov-table-row v-if="location.hasOwnProperty('image_file_id')">
           <gov-table-header top scope="row">Image</gov-table-header>
           <gov-table-cell>


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/3307/add-new-approve-and-edit-button-to-update-requests

- Add approve and edit button to update requests
- When clicked, update request is approved and the user is moved to the entity's edit view

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
