### PR TITLE
Added missing excerpt field to update request page details

### DIFF
--- a/src/views/update-requests/show/PageDetails.vue
+++ b/src/views/update-requests/show/PageDetails.vue
@@ -48,6 +48,14 @@
           <gov-table-cell>{{ page.slug }}</gov-table-cell>
         </gov-table-row>
 
+        <gov-table-row v-if="page.hasOwnProperty('excerpt')">
+          <gov-table-header top scope="row">Excerpt</gov-table-header>
+          <gov-table-cell v-if="original">{{
+            original.excerpt | originalExists
+          }}</gov-table-cell>
+          <gov-table-cell>{{ page.excerpt }}</gov-table-cell>
+        </gov-table-row>
+
         <gov-table-row v-if="page.hasOwnProperty('enabled')">
           <gov-table-header top scope="row">Status</gov-table-header>
           <gov-table-cell v-if="original">{{


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/4414/bug-update-requests-corrupt-when-multiple-update-requests-are-made

- Excerpt field was missing from update request page details.
- Added in excerpt field to page details

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
