### PR TITLE
Fixed organisation edit button not showing for org admin

### DIFF
--- a/src/views/organisations/Show.vue
+++ b/src/views/organisations/Show.vue
@@ -30,13 +30,13 @@
 
             <ck-delete-button
               resource="organisation"
-              :endpoint="`/organisations/${this.organisation.id}`"
+              :endpoint="`/organisations/${organisation.id}`"
               @deleted="onDelete"
             />
           </template>
         </gov-grid-column>
         <gov-grid-column
-          v-if="auth.canEdit('organisation', organisation)"
+          v-if="auth.canEdit('organisation', organisation.id)"
           width="one-third"
           class="text-right"
         >


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/4427/edit-button-not-appearing-for-organisation-admins

- Fixed call to `auth.canEdit`

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
