### PR TITLE
Fixed missing edit button in event show view

### DIFF
--- a/src/views/events/Show.vue
+++ b/src/views/events/Show.vue
@@ -18,7 +18,7 @@
               >
             </gov-grid-column>
             <gov-grid-column
-              v-if="auth.canEdit('event', event.organisation)"
+              v-if="auth.canEdit('event', event.organisation.id)"
               width="one-third"
               class="text-right"
             >


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/4465/edit-button-not-appearing-when-editing-events

- Fixed call to `auth.canEdit` in event show view

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
