### PR TITLE
Added social medias comparison to organisation details in update request view

### DIFF
--- a/src/views/update-requests/show/OrganisationDetails.vue
+++ b/src/views/update-requests/show/OrganisationDetails.vue
@@ -61,6 +61,43 @@
           <gov-table-cell>{{ organisation.phone || "-" }}</gov-table-cell>
         </gov-table-row>
 
+        <gov-table-row v-if="organisation.hasOwnProperty('social_medias')">
+          <gov-table-header top scope="row">Social medias</gov-table-header>
+          <gov-table-cell break v-if="original">
+            <gov-list
+              v-if="
+                original.hasOwnProperty('social_medias') &&
+                  Array.isArray(original.social_medias)
+              "
+            >
+              <li
+                v-for="(socialMedia, index) in original.social_medias"
+                :key="`social_media.${index}`"
+              >
+                <span class="govuk-!-font-weight-bold"
+                  >{{ socialMedia.type | socialMediaType }}:</span
+                >
+                {{ socialMedia.url }}
+              </li>
+            </gov-list>
+            <template v-else>None</template>
+          </gov-table-cell>
+          <gov-table-cell break>
+            <gov-list v-if="Array.isArray(organisation.social_medias)">
+              <li
+                v-for="(socialMedia, index) in organisation.social_medias"
+                :key="`social_media.${index}`"
+              >
+                <span class="govuk-!-font-weight-bold"
+                  >{{ socialMedia.type | socialMediaType }}:</span
+                >
+                {{ socialMedia.url }}
+              </li>
+            </gov-list>
+            <template v-else>None</template>
+          </gov-table-cell>
+        </gov-table-row>
+
         <gov-table-row v-if="organisation.hasOwnProperty('description')">
           <gov-table-header top scope="row">Description</gov-table-header>
           <gov-table-cell


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/4165/add-in-social-media-links-to-services

- `organisationDetails` component in the update request `Show` view was missing the template section to show changes to the social medias
- Added in the template elements to display the differences in social medias

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
