### PR TITLE
Refactored update request index and approve and edit

### DIFF
--- a/src/views/update-requests/Index.vue
+++ b/src/views/update-requests/Index.vue
@@ -96,34 +96,30 @@ export default {
       },
       updateableTypes: [
         { value: "", text: "All" },
-        { value: "services", text: "Service update" },
-        {
-          value: "new_service_created_by_org_admin",
-          text: "New Service by Organisation Admin"
-        },
-        {
-          value: "new_service_created_by_global_admin",
-          text: "New Service by Global Admin"
-        },
-        { value: "service_locations", text: "Service location" },
-        { value: "organisations", text: "Organisation update" },
-        {
-          value: "new_organisation_created_by_global_admin",
-          text: "New Organisation"
-        },
-        { value: "locations", text: "Location" },
-        {
-          value: "organisation_sign_up_form",
-          text: "Organisation sign up form"
-        },
-        { value: "organisation_events", text: "Event update" },
         {
           value: "new_organisation_event_created_by_org_admin",
           text: "New Event"
         },
-        { value: "pages", text: "Page update" },
+        { value: "organisation_events", text: "Event update" },
+        { value: "locations", text: "Location" },
+        {
+          value: "new_organisation_created_by_global_admin",
+          text: "New Organisation"
+        },
+        { value: "organisations", text: "Organisation update" },
+        {
+          value: "organisation_sign_up_form",
+          text: "Organisation sign up form"
+        },
         { value: "new_page", text: "New Page" },
-        { value: "referrals", text: "Referral" }
+        { value: "pages", text: "Page update" },
+        { value: "referrals", text: "Referral" },
+        {
+          value: "new_service_created_by_global_admin",
+          text: "New Service"
+        },
+        { value: "services", text: "Service update" },
+        { value: "service_locations", text: "Service location" }
       ]
     };
   },

--- a/src/views/update-requests/Show.vue
+++ b/src/views/update-requests/Show.vue
@@ -231,22 +231,19 @@ export default {
       this.submitting = true;
       this.form.$errors.clear();
 
-      if (this.approve === "approve" || this.approve === "approve_edit") {
+      if (this.approve !== "reject") {
+        const routeAction = this.approve === "approve_edit" ? "edit" : "show";
+
         const {
           data: { updateable_id }
-        } = await http.put(`/update-requests/${this.updateRequest.id}/approve`);
-
-        const routeAction = this.approve === "approve_edit" ? "edit" : "show";
+        } = await http.put(
+          `/update-requests/${this.updateRequest.id}/approve?action=${routeAction}`
+        );
 
         switch (this.updateRequest.updateable_type) {
           case "services":
           case "new_service_created_by_org_admin":
           case "new_service_created_by_global_admin":
-            if (this.approve === "approve_edit") {
-              await new Form({ status: "inactive" }).put(
-                `/services/${updateable_id}`
-              );
-            }
             this.$router.push({
               name: "services-" + routeAction,
               params: { service: updateable_id }
@@ -261,9 +258,6 @@ export default {
             break;
           case "pages":
           case "new_page":
-            if (this.approve === "approve_edit") {
-              await new Form({ enabled: false }).put(`/pages/${updateable_id}`);
-            }
             this.$router.push({
               name: "pages-" + routeAction,
               params: { page: updateable_id }


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/3307/add-new-approve-and-edit-button-to-update-requests

- Refactored the update request list to improve the UI
- Changed the approve and edit submission process so there is not a update request to disable pages and services first. This is now managed by the API. Instead an `action` flag is passed to indicate if this is an approve or approve and edit submission.

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
