### PR TITLE
Add warnings and disable submit button when image changes are pending

### DIFF
--- a/src/views/collections/categories/Create.vue
+++ b/src/views/collections/categories/Create.vue
@@ -30,12 +30,19 @@
             :category_taxonomies.sync="form.category_taxonomies"
             :image_file_id.sync="form.image_file_id"
             @clear="form.$errors.clear($event)"
+            @image-changed="imageChanged = $event"
           />
 
           <gov-button v-if="form.$submitting" disabled type="submit"
             >Creating...</gov-button
           >
-          <gov-button v-else @click="onSubmit" type="submit">Create</gov-button>
+          <gov-button
+            v-else
+            @click="onSubmit"
+            :disabled="imageChanged"
+            type="submit"
+            >Create</gov-button
+          >
           <ck-submit-error v-if="form.$errors.any()" />
         </gov-grid-column>
       </gov-grid-row>
@@ -52,6 +59,7 @@ export default {
   components: { CollectionForm },
   data() {
     return {
+      imageChanged: false,
       form: new Form({
         name: "",
         intro: "",

--- a/src/views/collections/categories/Edit.vue
+++ b/src/views/collections/categories/Edit.vue
@@ -35,12 +35,17 @@
               :category_taxonomies.sync="form.category_taxonomies"
               :image_file_id.sync="form.image_file_id"
               @clear="form.$errors.clear($event)"
+              @image-changed="imageChanged = $event"
             />
 
             <gov-button v-if="form.$submitting" disabled type="submit"
               >Updating...</gov-button
             >
-            <gov-button v-else @click="onSubmit" type="submit"
+            <gov-button
+              v-else
+              @click="onSubmit"
+              :disabled="imageChanged"
+              type="submit"
               >Update</gov-button
             >
             <ck-submit-error v-if="form.$errors.any()" />
@@ -71,7 +76,8 @@ export default {
     return {
       loading: false,
       collection: null,
-      form: null
+      form: null,
+      imageChanged: false
     };
   },
   methods: {

--- a/src/views/collections/categories/forms/CollectionForm.vue
+++ b/src/views/collections/categories/forms/CollectionForm.vue
@@ -24,6 +24,7 @@
 
     <ck-image-input
       @input="onInput('image_file_id', $event.file_id)"
+      @image-changed="$emit('image-changed', $event)"
       id="image"
       label="Category image"
       :file-id="image_file_id"

--- a/src/views/collections/events/Create.vue
+++ b/src/views/collections/events/Create.vue
@@ -29,12 +29,18 @@
             :category_taxonomies.sync="form.category_taxonomies"
             :image_file_id.sync="form.image_file_id"
             @clear="form.$errors.clear($event)"
+            @image-changed="imageChanged = $event"
           />
 
           <gov-button v-if="form.$submitting" disabled type="submit"
             >Creating...</gov-button
           >
-          <gov-button v-else @click="onSubmit" type="submit">
+          <gov-button
+            v-else
+            @click="onSubmit"
+            :disabled="imageChanged"
+            type="submit"
+          >
             Create
           </gov-button>
           <ck-submit-error v-if="form.$errors.any()" />
@@ -53,6 +59,7 @@ export default {
   components: { CollectionForm },
   data() {
     return {
+      imageChanged: false,
       form: new Form({
         name: "",
         intro: "",

--- a/src/views/collections/events/Edit.vue
+++ b/src/views/collections/events/Edit.vue
@@ -35,12 +35,17 @@
               :category_taxonomies.sync="form.category_taxonomies"
               :image_file_id.sync="form.image_file_id"
               @clear="form.$errors.clear($event)"
+              @image-changed="imageChanged = $event"
             />
 
             <gov-button v-if="form.$submitting" disabled type="submit"
               >Updating...</gov-button
             >
-            <gov-button v-else @click="onSubmit" type="submit"
+            <gov-button
+              v-else
+              @click="onSubmit"
+              :disabled="imageChanged"
+              type="submit"
               >Update</gov-button
             >
             <ck-submit-error v-if="form.$errors.any()" />
@@ -73,7 +78,8 @@ export default {
     return {
       loading: false,
       collection: null,
-      form: null
+      form: null,
+      imageChanged: false
     };
   },
   methods: {

--- a/src/views/collections/events/forms/CollectionForm.vue
+++ b/src/views/collections/events/forms/CollectionForm.vue
@@ -24,6 +24,7 @@
 
     <ck-image-input
       @input="onInput('image_file_id', $event.file_id)"
+      @image-changed="$emit('image-changed', $event)"
       id="image"
       label="Event collection image"
       :file-id="image_file_id"

--- a/src/views/collections/personas/Create.vue
+++ b/src/views/collections/personas/Create.vue
@@ -31,12 +31,18 @@
             :category_taxonomies.sync="form.category_taxonomies"
             :image_file_id.sync="form.image_file_id"
             @clear="form.$errors.clear($event)"
+            @image-changed="imageChanged = $event"
           />
 
           <gov-button v-if="form.$submitting" disabled type="submit"
             >Creating...</gov-button
           >
-          <gov-button v-else @click="onSubmit" type="submit">
+          <gov-button
+            v-else
+            @click="onSubmit"
+            :disabled="imageChanged"
+            type="submit"
+          >
             Create
           </gov-button>
           <ck-submit-error v-if="form.$errors.any()" />
@@ -55,6 +61,7 @@ export default {
   components: { CollectionForm },
   data() {
     return {
+      imageChanged: false,
       form: new Form({
         name: "",
         intro: "",

--- a/src/views/collections/personas/Edit.vue
+++ b/src/views/collections/personas/Edit.vue
@@ -36,12 +36,17 @@
               :category_taxonomies.sync="form.category_taxonomies"
               :image_file_id.sync="form.image_file_id"
               @clear="form.$errors.clear($event)"
+              @image-changed="imageChanged = $event"
             />
 
             <gov-button v-if="form.$submitting" disabled type="submit"
               >Updating...</gov-button
             >
-            <gov-button v-else @click="onSubmit" type="submit"
+            <gov-button
+              v-else
+              @click="onSubmit"
+              :disabled="imageChanged"
+              type="submit"
               >Update</gov-button
             >
             <ck-submit-error v-if="form.$errors.any()" />
@@ -72,7 +77,8 @@ export default {
     return {
       loading: false,
       collection: null,
-      form: null
+      form: null,
+      imageChanged: false
     };
   },
   methods: {

--- a/src/views/collections/personas/forms/CollectionForm.vue
+++ b/src/views/collections/personas/forms/CollectionForm.vue
@@ -37,10 +37,19 @@
 
     <ck-image-input
       @input="onInput('image_file_id', $event.file_id)"
+      @image-changed="$emit('image-changed', $event)"
       id="image"
       label="Persona image"
       :file-id="image_file_id"
-    />
+    >
+      <template slot="after-error-message">
+        <gov-error-message
+          v-if="errors.get('image_file_id')"
+          v-text="errors.get('image_file_id')"
+          for="image"
+        />
+      </template>
+    </ck-image-input>
 
     <collection-homepage-input
       :value="homepage"

--- a/src/views/events/Create.vue
+++ b/src/views/events/Create.vue
@@ -82,6 +82,7 @@
                 :location_id.sync="form.location_id"
                 :image_file_id.sync="form.image_file_id"
                 @clear="form.$errors.clear($event)"
+                @image-changed="imageChanged = $event"
               />
               <taxonomies-tab
                 v-if="isTabActive('taxonomies')"
@@ -99,7 +100,11 @@
             <gov-button v-if="form.$submitting" disabled type="submit"
               >Creating...</gov-button
             >
-            <gov-button v-else @click="onSubmit" type="submit"
+            <gov-button
+              v-else
+              @click="onSubmit"
+              :disabled="imageChanged"
+              type="submit"
               >Create</gov-button
             >
             <ck-submit-error v-if="form.$errors.any()" />
@@ -158,7 +163,8 @@ export default {
       organisations: [{ text: "Please select", value: null }],
       updateRequestCreated: false,
       updateRequestMessage: null,
-      loading: false
+      loading: false,
+      imageChanged: false
     };
   },
 

--- a/src/views/events/Edit.vue
+++ b/src/views/events/Edit.vue
@@ -58,6 +58,7 @@
                 :location_id.sync="form.location_id"
                 :image_file_id.sync="form.image_file_id"
                 @clear="form.$errors.clear($event)"
+                @image-changed="imageChanged = $event"
               />
               <taxonomies-tab
                 v-if="isTabActive('taxonomies')"
@@ -80,9 +81,13 @@
             <gov-button v-if="form.$submitting" disabled type="submit"
               >Requesting...</gov-button
             >
-            <gov-button v-else @click="onSubmit" type="submit">{{
-              updateButtonText
-            }}</gov-button>
+            <gov-button
+              v-else
+              @click="onSubmit"
+              :disabled="imageChanged"
+              type="submit"
+              >{{ updateButtonText }}</gov-button
+            >
             <ck-submit-error v-if="form.$errors.any()" />
           </gov-grid-column>
         </gov-grid-row>
@@ -110,7 +115,8 @@ export default {
       ],
       loading: false,
       event: null,
-      form: null
+      form: null,
+      imageChanged: false
     };
   },
 

--- a/src/views/events/forms/DetailsTab.vue
+++ b/src/views/events/forms/DetailsTab.vue
@@ -276,6 +276,7 @@
 
     <ck-image-input
       @input="onInput('image_file_id', $event.file_id)"
+      @image-changed="$emit('image-changed', $event)"
       id="image"
       label="Event image"
       :file-id="image_file_id"

--- a/src/views/locations/Create.vue
+++ b/src/views/locations/Create.vue
@@ -29,12 +29,19 @@
             :has_accessible_toilet.sync="form.has_accessible_toilet"
             :image_file_id.sync="form.image_file_id"
             @clear="form.$errors.clear($event)"
+            @image-changed="imageChanged = $event"
           />
 
           <gov-button v-if="form.$submitting" disabled type="submit"
             >Creating...</gov-button
           >
-          <gov-button v-else @click="onSubmit" type="submit">Create</gov-button>
+          <gov-button
+            v-else
+            @click="onSubmit"
+            :disabled="imageChanged"
+            type="submit"
+            >Create</gov-button
+          >
           <ck-submit-error v-if="form.$errors.any()" />
         </gov-grid-column>
       </gov-grid-row>
@@ -51,6 +58,7 @@ export default {
   components: { LocationForm },
   data() {
     return {
+      imageChanged: false,
       form: new Form({
         address_line_1: "",
         address_line_2: "",

--- a/src/views/locations/Edit.vue
+++ b/src/views/locations/Edit.vue
@@ -35,6 +35,7 @@
               :has_accessible_toilet.sync="form.has_accessible_toilet"
               :image_file_id.sync="form.image_file_id"
               @clear="form.$errors.clear($event)"
+              @image-changed="imageChanged = $event"
             />
 
             <gov-warning-text>
@@ -45,9 +46,13 @@
             <gov-button v-if="form.$submitting" disabled type="submit"
               >Requesting...</gov-button
             >
-            <gov-button v-else @click="onSubmit" type="submit">{{
-              updateButtonText
-            }}</gov-button>
+            <gov-button
+              :disabled="imageChanged"
+              v-else
+              @click="onSubmit"
+              type="submit"
+              >{{ updateButtonText }}</gov-button
+            >
             <ck-submit-error v-if="form.$errors.any()" />
           </gov-grid-column>
         </gov-grid-row>
@@ -68,7 +73,8 @@ export default {
     return {
       loading: false,
       location: null,
-      form: null
+      form: null,
+      imageChanged: false
     };
   },
   computed: {

--- a/src/views/locations/forms/LocationForm.vue
+++ b/src/views/locations/forms/LocationForm.vue
@@ -126,6 +126,7 @@
 
     <ck-image-input
       @input="onInput('image_file_id', $event.file_id)"
+      @image-changed="$emit('image-changed', $event)"
       id="image"
       label="Location image"
       :file-id="image_file_id"

--- a/src/views/organisations/Create.vue
+++ b/src/views/organisations/Create.vue
@@ -57,6 +57,7 @@
                   :social_medias.sync="form.social_medias"
                   @update:logo_file_id="form.logo_file_id = $event"
                   @clear="form.$errors.clear($event)"
+                  @image-changed="imageChanged = $event"
                 />
               </organisation-tab>
 
@@ -99,7 +100,11 @@
             <gov-button v-if="form.$submitting" disabled type="submit"
               >Creating...</gov-button
             >
-            <gov-button v-else @click="onSubmit" type="submit"
+            <gov-button
+              v-else
+              @click="onSubmit"
+              :disabled="imageChanged"
+              type="submit"
               >Create</gov-button
             >
             <ck-submit-error v-if="form.$errors.any()" />
@@ -137,7 +142,8 @@ export default {
         { id: "taxonomies", heading: "Taxonomies", active: false }
       ],
       updateRequestCreated: false,
-      updateRequestMessage: null
+      updateRequestMessage: null,
+      imageChanged: false
     };
   },
   watch: {

--- a/src/views/organisations/Edit.vue
+++ b/src/views/organisations/Edit.vue
@@ -54,6 +54,7 @@
                   :social_medias.sync="form.social_medias"
                   :logo_file_id.sync="form.logo_file_id"
                   @clear="form.$errors.clear($event)"
+                  @image-changed="imageChanged = $event"
                 />
               </organisation-tab>
 
@@ -99,9 +100,13 @@
             <gov-button v-if="form.$submitting" disabled type="submit"
               >Requesting...</gov-button
             >
-            <gov-button v-else @click="onSubmit" type="submit">{{
-              updateButtonText
-            }}</gov-button>
+            <gov-button
+              v-else
+              @click="onSubmit"
+              :disabled="imageChanged"
+              type="submit"
+              >{{ updateButtonText }}</gov-button
+            >
             <ck-submit-error v-if="form.$errors.any()" />
           </gov-grid-column>
         </gov-grid-row>
@@ -128,7 +133,8 @@ export default {
       tabs: [
         { id: "details", heading: "Details", active: true },
         { id: "taxonomies", heading: "Taxonomies", active: false }
-      ]
+      ],
+      imageChanged: false
     };
   },
   computed: {

--- a/src/views/organisations/forms/OrganisationForm.vue
+++ b/src/views/organisations/forms/OrganisationForm.vue
@@ -63,6 +63,7 @@
 
     <ck-image-input
       @input="onInput('logo_file_id', $event.file_id)"
+      @image-changed="$emit('image-changed', $event)"
       id="logo"
       label="Organisation logo"
       :file-id="logo_file_id"

--- a/src/views/pages/Create.vue
+++ b/src/views/pages/Create.vue
@@ -18,6 +18,7 @@
         :collections.sync="form.collections"
         :enabled.sync="form.enabled"
         @clear="form.$errors.clear($event)"
+        @image-changed="imageChanged = $event"
       />
     </gov-main-wrapper>
 
@@ -28,7 +29,7 @@
     >
     <gov-button
       v-else
-      :disabled="form.$errors.any()"
+      :disabled="form.$errors.any() || imageChanged"
       @click="onSubmit"
       type="submit"
       >Create</gov-button
@@ -133,7 +134,8 @@ export default {
             ]
           }
         }
-      }
+      },
+      imageChanged: false
     };
   },
 

--- a/src/views/pages/Edit.vue
+++ b/src/views/pages/Edit.vue
@@ -21,6 +21,7 @@
           :collections.sync="form.collections"
           :enabled.sync="form.enabled"
           @clear="form.$errors.clear($event)"
+          @image-changed="imageChanged = $event"
         />
 
         <gov-section-break size="l" />
@@ -28,9 +29,13 @@
         <gov-button v-if="form.$submitting" disabled type="submit"
           >Updating...</gov-button
         >
-        <gov-button v-else @click="onSubmit" type="submit">{{
-          updateButtonText
-        }}</gov-button>
+        <gov-button
+          v-else
+          @click="onSubmit"
+          :disabled="imageChanged"
+          type="submit"
+          >{{ updateButtonText }}</gov-button
+        >
 
         <ck-submit-error v-if="form.$errors.any()" />
       </gov-main-wrapper>
@@ -54,7 +59,8 @@ export default {
     return {
       loading: false,
       page: null,
-      form: null
+      form: null,
+      imageChanged: false
     };
   },
   computed: {

--- a/src/views/pages/forms/PageForm.vue
+++ b/src/views/pages/forms/PageForm.vue
@@ -56,6 +56,7 @@
 
     <ck-image-input
       @input="onInput('image_file_id', $event.file_id)"
+      @image-changed="$emit('image-changed', $event)"
       id="image"
       label="Page Image"
       :file-id="image_file_id"

--- a/src/views/services/Create.vue
+++ b/src/views/services/Create.vue
@@ -66,10 +66,6 @@
             <gov-tabs @tab-changed="onTabChange" :tabs="allowedTabs" no-router>
               <details-tab
                 v-show="isTabActive('details')"
-                @clear="
-                  form.$errors.clear($event);
-                  errors = {};
-                "
                 :errors="form.$errors"
                 :is-new="true"
                 :name.sync="form.name"
@@ -77,12 +73,17 @@
                 :type.sync="form.type"
                 :organisation_id.sync="form.organisation_id"
                 :url.sync="form.url"
-                @update:logo_file_id="form.logo_file_id = $event"
                 :status.sync="form.status"
                 :score.sync="form.score"
                 :ends_at.sync="form.ends_at"
                 :gallery_items.sync="form.gallery_items"
                 :tags.sync="form.tags"
+                @clear="
+                  form.$errors.clear($event);
+                  errors = {};
+                "
+                @update:logo_file_id="form.logo_file_id = $event"
+                @image-changed="imageChanged = $event"
               >
                 <gov-button @click="onNext" start>Next</gov-button>
               </details-tab>
@@ -184,7 +185,11 @@
                 <gov-button v-if="form.$submitting" disabled type="submit"
                   >Creating...</gov-button
                 >
-                <gov-button v-else @click="onSubmit" type="submit"
+                <gov-button
+                  v-else
+                  @click="onSubmit"
+                  :disabled="imageChanged"
+                  type="submit"
                   >Create</gov-button
                 >
                 <ck-submit-error v-if="form.$errors.any()" />
@@ -286,7 +291,8 @@ export default {
         { id: "referral", heading: "Referral", active: false }
       ],
       updateRequestCreated: false,
-      updateRequestMessage: null
+      updateRequestMessage: null,
+      imageChanged: false
     };
   },
   computed: {

--- a/src/views/services/Edit.vue
+++ b/src/views/services/Edit.vue
@@ -37,10 +37,6 @@
               >
                 <details-tab
                   v-show="isTabActive('details')"
-                  @clear="
-                    form.$errors.clear($event);
-                    errors = {};
-                  "
                   :errors="form.$errors"
                   :organisation_id.sync="form.organisation_id"
                   :name.sync="form.name"
@@ -48,13 +44,18 @@
                   :type.sync="form.type"
                   :url.sync="form.url"
                   :logo_file_id.sync="form.logo_file_id"
-                  @update:logo="form.logo = $event"
                   :status.sync="form.status"
                   :score.sync="form.score"
                   :ends_at.sync="form.ends_at"
                   :gallery_items.sync="form.gallery_items"
                   :tags.sync="form.tags"
                   :id="service.id"
+                  @clear="
+                    form.$errors.clear($event);
+                    errors = {};
+                  "
+                  @update:logo="form.logo = $event"
+                  @image-changed="imageChanged = $event"
                 >
                   <gov-button @click="onNext" start>Next</gov-button>
                 </details-tab>
@@ -218,9 +219,13 @@
               <gov-button v-if="form.$submitting" disabled type="submit"
                 >Requesting...</gov-button
               >
-              <gov-button v-else @click="onSubmit" type="submit">{{
-                updateButtonText
-              }}</gov-button>
+              <gov-button
+                v-else
+                @click="onSubmit"
+                :disabled="imageChanged"
+                type="submit"
+                >{{ updateButtonText }}</gov-button
+              >
             </gov-grid-column>
           </gov-grid-row>
         </gov-main-wrapper>
@@ -268,7 +273,8 @@ export default {
       errors: {},
       service: null,
       loading: false,
-      updateRequest: null
+      updateRequest: null,
+      imageChanged: false
     };
   },
   computed: {

--- a/src/views/services/forms/DetailsTab.vue
+++ b/src/views/services/forms/DetailsTab.vue
@@ -103,6 +103,7 @@
             $emit('update:logo_file_id', $event.file_id);
             $emit('update:logo', $event.image);
           "
+          @image-changed="$emit('image-changed', $event)"
           id="logo"
           :label="`Upload your ${type} logo`"
           :file-id="logo_file_id"


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/4200/add-in-alt-text-fields

- Added warning when image file or alt text has been changed but not uploaded
- Disable submit button when image file or alt text has been changed but not uploaded

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
