### PR TITLE
Added feature flag for service offerings UI

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -184,6 +184,11 @@ Vue.mixin({
         ? process.env.VUE_APP_SERVICE_TAGS === "true"
         : false;
     },
+    appServiceOfferingsActive() {
+      return process.env.hasOwnProperty("VUE_APP_SERVICE_OFFERINGS")
+        ? process.env.VUE_APP_SERVICE_OFFERINGS === "true"
+        : false;
+    },
     appHelpSectionActive() {
       return process.env.hasOwnProperty("VUE_APP_HELP_SECTION")
         ? process.env.VUE_APP_HELP_SECTION === "true"

--- a/src/views/services/forms/DescriptionTab.vue
+++ b/src/views/services/forms/DescriptionTab.vue
@@ -23,22 +23,24 @@
           :error="errors.get('intro')"
         />
 
-        <gov-heading size="m">What you offer</gov-heading>
+        <template v-if="appServiceOfferingsActive">
+          <gov-heading size="m">What you offer</gov-heading>
 
-        <gov-body>
-          Include a bullet list of some of the things you do as a {{ type }}.
-        </gov-body>
+          <gov-body>
+            Include a bullet list of some of the things you do as a {{ type }}.
+          </gov-body>
 
-        <gov-body>
-          For example: (Weekly Meetups, Peer Support, Group Therapy)
-        </gov-body>
+          <gov-body>
+            For example: (Weekly Meetups, Peer Support, Group Therapy)
+          </gov-body>
 
-        <ck-offerings-input
-          :offerings="offerings"
-          @input="$emit('update:offerings', $event)"
-          @clear="$emit('clear', $event)"
-          :errors="errors"
-        />
+          <ck-offerings-input
+            :offerings="offerings"
+            @input="$emit('update:offerings', $event)"
+            @clear="$emit('clear', $event)"
+            :errors="errors"
+          />
+        </template>
 
         <ck-wysiwyg-input
           :value="description"

--- a/src/views/services/show/DetailsTab.vue
+++ b/src/views/services/show/DetailsTab.vue
@@ -41,7 +41,7 @@
           >
           <gov-table-cell v-html="toHtml(service.description)" />
         </gov-table-row>
-        <gov-table-row>
+        <gov-table-row v-if="appServiceOfferingsActive">
           <gov-table-header top scope="row">Offerings</gov-table-header>
           <gov-table-cell>
             <gov-list v-if="service.offerings.length > 0" bullet>


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/4545/make-the-what-we-offer-field-feature-flagable

- Added feature flag `VUE_APP_SERVICE_OFFERINGS`
- Wrapped service offerings UI in tests for feature flag

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
