### PR TITLE
Feature/sc 4586/edit button missing

### DIFF
--- a/src/views/events/Show.vue
+++ b/src/views/events/Show.vue
@@ -93,6 +93,7 @@ export default {
   created() {
     this.updated = this.$route.query.updated || false;
     this.fetchEvent();
+    this.auth.fetchUser();
   }
 };
 </script>

--- a/src/views/organisations/Show.vue
+++ b/src/views/organisations/Show.vue
@@ -83,6 +83,7 @@ export default {
   created() {
     this.updated = this.$route.query.updated || false;
     this.fetchOrganisation();
+    this.auth.fetchUser();
   }
 };
 </script>

--- a/src/views/pages/Show.vue
+++ b/src/views/pages/Show.vue
@@ -18,7 +18,7 @@
               >
             </gov-grid-column>
             <gov-grid-column
-              v-if="auth.canEdit('page', page)"
+              v-if="auth.canEdit('page', page.id)"
               width="one-third"
               class="text-right"
             >
@@ -134,6 +134,7 @@ export default {
   created() {
     this.updated = this.$route.query.updated || false;
     this.fetchPage();
+    this.auth.fetchUser();
   }
 };
 </script>

--- a/src/views/referrals/Show.vue
+++ b/src/views/referrals/Show.vue
@@ -16,7 +16,7 @@
         </gov-grid-row>
         <gov-section-break size="l" />
         <gov-grid-row
-          v-if="auth.canEdit('referral', referral.service.id)"
+          v-if="auth.canEdit('referral', referral.service_id)"
           width="two-thirds"
         >
           <gov-grid-column width="two-thirds">
@@ -125,104 +125,104 @@
 </template>
 
 <script>
-import http from "@/http";
-import Form from "@/classes/Form";
+  import http from '@/http';
+  import Form from '@/classes/Form';
 
-export default {
-  name: "ShowReferral",
-  data() {
-    return {
-      loadingReferral: false,
-      loadingStatusUpdates: false,
-      referral: null,
-      statusUpdates: [],
-      currentPage: 1,
-      lastPage: 1,
-      statusOptions: [
-        { text: "New", value: "new" },
-        { text: "In progress", value: "in_progress" },
-        { text: "Completed", value: "completed" },
-        { text: "Incomplete", value: "incompleted" }
-      ],
-      form: new Form({
-        status: null,
-        comments: ""
-      })
-    };
-  },
-  methods: {
-    fetchReferral() {
-      this.loadingReferral = true;
-
-      http
-        .get(`/referrals/${this.$route.params.referral}`, {
-          params: {
-            include: "service"
-          }
-        })
-        .then(({ data }) => {
-          this.referral = data.data;
-          this.form.status = this.referral.status;
-          this.loadingReferral = false;
-        });
-    },
-    fetchStatusUpdates() {
-      this.loadingStatusUpdates = true;
-
-      const config = {
-        params: {
-          "filter[referral_id]": this.$route.params.referral,
-          include: "user"
-        }
+  export default {
+    name: 'ShowReferral',
+    data() {
+      return {
+        loadingReferral: false,
+        loadingStatusUpdates: false,
+        referral: null,
+        statusUpdates: [],
+        currentPage: 1,
+        lastPage: 1,
+        statusOptions: [
+          { text: 'New', value: 'new' },
+          { text: 'In progress', value: 'in_progress' },
+          { text: 'Completed', value: 'completed' },
+          { text: 'Incomplete', value: 'incompleted' },
+        ],
+        form: new Form({
+          status: null,
+          comments: '',
+        }),
       };
+    },
+    methods: {
+      fetchReferral() {
+        this.loadingReferral = true;
 
-      http.get("/status-updates", config).then(({ data }) => {
-        this.statusUpdates = data.data;
-        this.currentPage = data.meta.current_page;
-        this.lastPage = data.meta.last_page;
-        this.loadingStatusUpdates = false;
-      });
-    },
-    onNext() {
-      this.currentPage++;
-      this.fetchStatusUpdates();
-    },
-    onPrevious() {
-      this.currentPage--;
-      this.fetchStatusUpdates();
-    },
-    onSubmit() {
-      this.form.put(`/referrals/${this.referral.id}`).then(() => {
-        this.form.comments = "";
-        this.form.$errors.clear();
-        this.fetchReferral();
+        http
+          .get(`/referrals/${this.$route.params.referral}`, {
+            params: {
+              include: 'service',
+            },
+          })
+          .then(({ data }) => {
+            this.referral = data.data;
+            this.form.status = this.referral.status;
+            this.loadingReferral = false;
+          });
+      },
+      fetchStatusUpdates() {
+        this.loadingStatusUpdates = true;
+
+        const config = {
+          params: {
+            'filter[referral_id]': this.$route.params.referral,
+            include: 'user',
+          },
+        };
+
+        http.get('/status-updates', config).then(({ data }) => {
+          this.statusUpdates = data.data;
+          this.currentPage = data.meta.current_page;
+          this.lastPage = data.meta.last_page;
+          this.loadingStatusUpdates = false;
+        });
+      },
+      onNext() {
+        this.currentPage++;
         this.fetchStatusUpdates();
-      });
+      },
+      onPrevious() {
+        this.currentPage--;
+        this.fetchStatusUpdates();
+      },
+      onSubmit() {
+        this.form.put(`/referrals/${this.referral.id}`).then(() => {
+          this.form.comments = '';
+          this.form.$errors.clear();
+          this.fetchReferral();
+          this.fetchStatusUpdates();
+        });
+      },
+      onDelete() {
+        this.$router.push({ name: 'referrals-index' });
+      },
     },
-    onDelete() {
-      this.$router.push({ name: "referrals-index" });
-    }
-  },
-  filters: {
-    status(status) {
-      switch (status) {
-        case "new":
-          return "New";
-        case "in_progress":
-          return "In progress";
-        case "completed":
-          return "Completed";
-        case "incompleted":
-          return "Incomplete";
-        default:
-          return "Invalid status";
-      }
-    }
-  },
-  created() {
-    this.fetchReferral();
-    this.fetchStatusUpdates();
-    this.auth.fetchUser();
-  }
-};
+    filters: {
+      status(status) {
+        switch (status) {
+          case 'new':
+            return 'New';
+          case 'in_progress':
+            return 'In progress';
+          case 'completed':
+            return 'Completed';
+          case 'incompleted':
+            return 'Incomplete';
+          default:
+            return 'Invalid status';
+        }
+      },
+    },
+    created() {
+      this.fetchReferral();
+      this.fetchStatusUpdates();
+      this.auth.fetchUser();
+    },
+  };
 </script>

--- a/src/views/referrals/Show.vue
+++ b/src/views/referrals/Show.vue
@@ -16,7 +16,7 @@
         </gov-grid-row>
         <gov-section-break size="l" />
         <gov-grid-row
-          v-if="auth.canEdit('referral', referral)"
+          v-if="auth.canEdit('referral', referral.service.id)"
           width="two-thirds"
         >
           <gov-grid-column width="two-thirds">
@@ -222,6 +222,7 @@ export default {
   created() {
     this.fetchReferral();
     this.fetchStatusUpdates();
+    this.auth.fetchUser();
   }
 };
 </script>

--- a/src/views/referrals/Show.vue
+++ b/src/views/referrals/Show.vue
@@ -125,104 +125,104 @@
 </template>
 
 <script>
-  import http from '@/http';
-  import Form from '@/classes/Form';
+import http from "@/http";
+import Form from "@/classes/Form";
 
-  export default {
-    name: 'ShowReferral',
-    data() {
-      return {
-        loadingReferral: false,
-        loadingStatusUpdates: false,
-        referral: null,
-        statusUpdates: [],
-        currentPage: 1,
-        lastPage: 1,
-        statusOptions: [
-          { text: 'New', value: 'new' },
-          { text: 'In progress', value: 'in_progress' },
-          { text: 'Completed', value: 'completed' },
-          { text: 'Incomplete', value: 'incompleted' },
-        ],
-        form: new Form({
-          status: null,
-          comments: '',
-        }),
-      };
-    },
-    methods: {
-      fetchReferral() {
-        this.loadingReferral = true;
+export default {
+  name: "ShowReferral",
+  data() {
+    return {
+      loadingReferral: false,
+      loadingStatusUpdates: false,
+      referral: null,
+      statusUpdates: [],
+      currentPage: 1,
+      lastPage: 1,
+      statusOptions: [
+        { text: "New", value: "new" },
+        { text: "In progress", value: "in_progress" },
+        { text: "Completed", value: "completed" },
+        { text: "Incomplete", value: "incompleted" }
+      ],
+      form: new Form({
+        status: null,
+        comments: ""
+      })
+    };
+  },
+  methods: {
+    fetchReferral() {
+      this.loadingReferral = true;
 
-        http
-          .get(`/referrals/${this.$route.params.referral}`, {
-            params: {
-              include: 'service',
-            },
-          })
-          .then(({ data }) => {
-            this.referral = data.data;
-            this.form.status = this.referral.status;
-            this.loadingReferral = false;
-          });
-      },
-      fetchStatusUpdates() {
-        this.loadingStatusUpdates = true;
-
-        const config = {
+      http
+        .get(`/referrals/${this.$route.params.referral}`, {
           params: {
-            'filter[referral_id]': this.$route.params.referral,
-            include: 'user',
-          },
-        };
+            include: "service"
+          }
+        })
+        .then(({ data }) => {
+          this.referral = data.data;
+          this.form.status = this.referral.status;
+          this.loadingReferral = false;
+        });
+    },
+    fetchStatusUpdates() {
+      this.loadingStatusUpdates = true;
 
-        http.get('/status-updates', config).then(({ data }) => {
-          this.statusUpdates = data.data;
-          this.currentPage = data.meta.current_page;
-          this.lastPage = data.meta.last_page;
-          this.loadingStatusUpdates = false;
-        });
-      },
-      onNext() {
-        this.currentPage++;
-        this.fetchStatusUpdates();
-      },
-      onPrevious() {
-        this.currentPage--;
-        this.fetchStatusUpdates();
-      },
-      onSubmit() {
-        this.form.put(`/referrals/${this.referral.id}`).then(() => {
-          this.form.comments = '';
-          this.form.$errors.clear();
-          this.fetchReferral();
-          this.fetchStatusUpdates();
-        });
-      },
-      onDelete() {
-        this.$router.push({ name: 'referrals-index' });
-      },
-    },
-    filters: {
-      status(status) {
-        switch (status) {
-          case 'new':
-            return 'New';
-          case 'in_progress':
-            return 'In progress';
-          case 'completed':
-            return 'Completed';
-          case 'incompleted':
-            return 'Incomplete';
-          default:
-            return 'Invalid status';
+      const config = {
+        params: {
+          "filter[referral_id]": this.$route.params.referral,
+          include: "user"
         }
-      },
+      };
+
+      http.get("/status-updates", config).then(({ data }) => {
+        this.statusUpdates = data.data;
+        this.currentPage = data.meta.current_page;
+        this.lastPage = data.meta.last_page;
+        this.loadingStatusUpdates = false;
+      });
     },
-    created() {
-      this.fetchReferral();
+    onNext() {
+      this.currentPage++;
       this.fetchStatusUpdates();
-      this.auth.fetchUser();
     },
-  };
+    onPrevious() {
+      this.currentPage--;
+      this.fetchStatusUpdates();
+    },
+    onSubmit() {
+      this.form.put(`/referrals/${this.referral.id}`).then(() => {
+        this.form.comments = "";
+        this.form.$errors.clear();
+        this.fetchReferral();
+        this.fetchStatusUpdates();
+      });
+    },
+    onDelete() {
+      this.$router.push({ name: "referrals-index" });
+    }
+  },
+  filters: {
+    status(status) {
+      switch (status) {
+        case "new":
+          return "New";
+        case "in_progress":
+          return "In progress";
+        case "completed":
+          return "Completed";
+        case "incompleted":
+          return "Incomplete";
+        default:
+          return "Invalid status";
+      }
+    }
+  },
+  created() {
+    this.fetchReferral();
+    this.fetchStatusUpdates();
+    this.auth.fetchUser();
+  }
+};
 </script>

--- a/src/views/service-locations/Show.vue
+++ b/src/views/service-locations/Show.vue
@@ -94,6 +94,7 @@ export default {
   created() {
     this.updated = this.$route.query.updated || false;
     this.fetchServiceLocation();
+    this.auth.fetchUser();
   }
 };
 </script>

--- a/src/views/services/Show.vue
+++ b/src/views/services/Show.vue
@@ -130,6 +130,7 @@ export default {
   created() {
     this.updated = this.$route.query.updated || false;
     this.fetchService();
+    this.auth.fetchUser();
   }
 };
 </script>


### PR DESCRIPTION
### Summary
https://app.shortcut.com/connectedplaces/story/4586/edit-button-missing

When a user other than a super admin views a service (or page, or event or any entity), we know whether to show the 'Edit' button by looking at the user object held by the Auth class, which was fetched either on login or on page refresh. The user object holds details of all the permissions the user has, i.e. which entities it has rights on.

When an entity is created through the update request cycle, the user object is not refreshed, so we don't know that the user has attained some new permissions. When the user then views the new entity, with their now outdated permissions, the Edit button doesn't show as they do not have a permission for that entity.

To resolve this we will need to fetch the user each time an entity is viewed, which is going to be unnecessary almost every time, as we don't know after requesting the new entity, when the admin will approve the update request. The only other option would be to have some push notification when an entity is created that would tell all active users to reload.

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
